### PR TITLE
feat(images): deterministic pregenerated rotation on play route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - **Runtime Pinning:** Added Node.js engine requirement `22.x` in `package.json` for deploy/runtime consistency.
 - **Vercel Hygiene:** Added `.vercel/` to `.gitignore` to avoid committing local deployment artifacts.
 - **E2E Reliability:** Removed legacy static-server branch from Playwright config, pinned e2e runtime defaults to safe mock mode, updated route-shell heading expectation, and migrated opt-in live canary flow to Grok/SvelteKit selectors.
+- **Pregenerated Image Rotation:** Updated `/play` image rendering to use deterministic randomized selection from `static/images`, so each scene resolves to a stable pre-generated art frame without requiring live image generation.
 
 ## [Unreleased] - 2026-02-05
 

--- a/src/lib/game/imagePaths.ts
+++ b/src/lib/game/imagePaths.ts
@@ -16,7 +16,54 @@ export const imagePaths: Record<string, string> = {
 	[ImageKeys.MOTEL_EXTERIOR]: '/images/motel_exterior.png'
 };
 
-export function resolveImagePath(imageKey: string | null | undefined): string {
+const pregeneratedImagePool: string[] = [
+	'/images/ChatGPT Image Feb 7, 2026, 03_33_36 AM.png',
+	'/images/ChatGPT Image Feb 7, 2026, 03_33_55 AM.png',
+	'/images/ChatGPT Image Feb 7, 2026, 03_34_02 AM.png',
+	'/images/ChatGPT Image Feb 7, 2026, 03_34_07 AM.png',
+	'/images/ChatGPT Image Feb 7, 2026, 03_34_13 AM.png',
+	'/images/ChatGPT Image Feb 7, 2026, 03_34_20 AM.png',
+	'/images/car_memory.png',
+	'/images/convenience_store.png',
+	'/images/empty_room.png',
+	'/images/hotel_room.png',
+	'/images/motel_exterior.png',
+	'/images/oswaldo_awake.png',
+	'/images/oswaldo_sleeping.png',
+	'/images/sydney_coffee_morning.png',
+	'/images/sydney_frustrated.png',
+	'/images/sydney_laptop.png',
+	'/images/sydney_oswaldo_tension.png',
+	'/images/sydney_phone_anxious.png',
+	'/images/sydney_thinking.png',
+	'/images/sydney_tired.png',
+	'/images/sydney_window_dawn.png',
+	'/images/the_door.png',
+	'/images/trina_crashed.png'
+].map((path) => encodeURI(path));
+
+function hashSeed(seed: string): number {
+	let hash = 2166136261;
+	for (let index = 0; index < seed.length; index += 1) {
+		hash ^= seed.charCodeAt(index);
+		hash = Math.imul(hash, 16777619);
+	}
+	return hash >>> 0;
+}
+
+function pickFromPool(seed: string): string | null {
+	if (pregeneratedImagePool.length === 0) return null;
+	const index = hashSeed(seed) % pregeneratedImagePool.length;
+	return pregeneratedImagePool[index];
+}
+
+export function resolveImagePath(
+	imageKey: string | null | undefined,
+	sceneId?: string | null
+): string {
+	const seed = (sceneId || imageKey || ImageKeys.HOTEL_ROOM).trim();
+	const pooled = pickFromPool(seed);
+	if (pooled) return pooled;
 	if (!imageKey) return imagePaths[ImageKeys.HOTEL_ROOM];
 	return imagePaths[imageKey] || imagePaths[ImageKeys.HOTEL_ROOM];
 }

--- a/src/lib/game/store.ts
+++ b/src/lib/game/store.ts
@@ -117,7 +117,7 @@ export const gameStore = {
 	clearError(): void {
 		appGameStateStore.update((state) => ({ ...state, error: '' }));
 	},
-	getImagePath(imageKey: string | null | undefined): string {
-		return resolveImagePath(imageKey);
+	getImagePath(imageKey: string | null | undefined, sceneId?: string | null): string {
+		return resolveImagePath(imageKey, sceneId);
 	}
 };

--- a/src/routes/play/+page.svelte
+++ b/src/routes/play/+page.svelte
@@ -48,7 +48,7 @@
 	}
 
 	function imagePath(): string {
-		return gameStore.getImagePath(scene?.imageKey);
+		return gameStore.getImagePath(scene?.imageKey, scene?.sceneId);
 	}
 </script>
 


### PR DESCRIPTION
## Summary
- switch play-route image rendering to deterministic rotation from the pre-generated static image pool
- keep selection stable per scene by hashing scene id/image key (no flicker on re-render)
- keep existing fallback mapping if the pool is unavailable

## Why
- lets demos use existing artwork immediately without live image generation
- uses the newly added image files automatically in gameplay

## Validation
- npm run check
- PLAYWRIGHT_BROWSERS_PATH=/mnt/c/Users/latro/Downloads/t/sydney-story/.playwright-browsers npm run test:e2e

## Notes
- live canary test was intentionally not run in this pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented deterministic pre-generated image rotation for the play scene, ensuring stable rendering without live image generation and providing consistent art frame selection based on scene context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->