### PR TITLE
Codex-generated pull request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- **Creator Workflow Route Group:** Added `/create/*` creator pages for template start, draft editing (metadata/prompts/theme/assets), play preview, and publish/unpublish version control with separate persisted draft vs publish state, explicit Draft/Ready/Published badges, and pre-publish validation messaging (`src/routes/create/+layout.svelte`, `src/routes/create/template/+page.svelte`, `src/routes/create/editor/+page.svelte`, `src/routes/create/preview/+page.svelte`, `src/routes/create/publish/+page.svelte`, `src/lib/creator/storyBuilder.ts`, `src/lib/creator/store.ts`, `src/routes/+layout.svelte`, `src/app.css`).
 - **Prompt Voice-Safety Reinforcement:** Added explicit forbidden-phrasing guidance to the main system prompt and recovery prompt path so didactic/therapy-summary drift is redirected to behavior+motive+consequence framing (`src/lib/server/ai/narrative.ts`).
 - **Narrative Prompt Encoding Cleanup:** Replaced mojibake-affected prompt markers/punctuation with ASCII-safe wording in active narrative prompt assets (`src/lib/server/ai/narrative.ts`, `docs/NARRATIVE_DRIFT_REMAINING_WORK_2026-02-13.md`).
 - **Context/Transition Test Hardening:** Added deterministic unit coverage that proves context budgeting trims older summaries before recent prose and that transition bridges emit mapped lines only when thread deltas exist (`tests/unit/contextBudget.spec.ts`, `tests/unit/transitionBridge.spec.ts`).
@@ -148,4 +149,3 @@
 - **Ending UX:** Endings no longer auto-jump to recap mid-typewriter. Players now click `View Recap` after ending text completes.
 - **Lesson Timing:** Lesson insight popup now appears only after scene text has finished typing.
 - **Regression Coverage:** Added renderer + e2e checks for delayed lesson display and recap transition/copy/download flow.
-

--- a/README.md
+++ b/README.md
@@ -10,11 +10,19 @@ No Vacancies is an interactive narrative game about invisible labor and relation
 - PWA assets: `static/manifest.json`, `static/service-worker.js`
 
 Demo readiness UX:
+
 - Home route (`/`) now includes a "Demo Readiness" progress dashboard backed by `/api/demo/readiness`.
 - Score/checks are runtime-derived (provider mode, key presence, outage mode, probe state) so you can quickly gauge demo readiness.
 - Debug route (`/debug`) shows persisted runtime/client/API error events to speed up playthrough troubleshooting.
 
+Creator UX:
+
+- New creator workspace routes under `/create/*` guide a safe four-step flow: template selection, draft editing, play preview, and publish/unpublish controls.
+- Draft state and published version state are persisted separately in local storage so editing never overwrites deployed versions.
+- Clear Draft/Ready/Published badges and publish-time validation messages prevent accidental release of incomplete content.
+
 Play UX:
+
 - `/play` uses a command-deck layout with clearer scene hierarchy, arc progress meter, and keyboard choice shortcuts (`1`, `2`, `3`) for faster turn selection.
 - `/play` also exposes quick utility controls (restart current run, jump to `/debug`) plus scene/arc/mood chips so operators can triage runs faster during demos.
 
@@ -36,6 +44,7 @@ cp .env.example .env.local
 ```
 
 Server/runtime variables used by the SvelteKit AI provider layer:
+
 - `AI_PROVIDER`: `grok` only (`mock` is disabled).
 - `AI_OUTAGE_MODE`: `hard_fail` (required in preview/production).
 - `XAI_API_KEY`: required in Grok-only mode.
@@ -45,6 +54,7 @@ Server/runtime variables used by the SvelteKit AI provider layer:
 - `AI_MAX_OUTPUT_TOKENS`, `AI_REQUEST_TIMEOUT_MS`, `AI_MAX_RETRIES`: optional reliability tuning.
 
 Default mode policy:
+
 - Text defaults to Grok (`AI Generated` mode in settings).
 - Images default to pre-generated/static unless `ENABLE_GROK_IMAGES=1`.
 - If Grok is unavailable or misconfigured, requests fail fast (no mock fallback path).
@@ -68,6 +78,7 @@ npm run test:e2e
 ```
 
 Notes:
+
 - `npm test` enforces the active-runtime decommission guard (`src/**`, `js/**`, `tests/e2e/**`, and `package.json` must stay free of legacy provider markers).
 - `npm run test:narrative` runs deterministic Tier 1 narrative quality gates (prompt wiring, context coverage, continuity dimensions, sanity contract, and fixture-based adversarial checks).
 - `npm run test:e2e` runs Playwright against the SvelteKit app.

--- a/src/app.css
+++ b/src/app.css
@@ -828,3 +828,179 @@ a {
 		transform: translateX(0);
 	}
 }
+
+.creator-shell {
+	display: grid;
+	gap: 14px;
+}
+
+.creator-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-start;
+	gap: 12px;
+	flex-wrap: wrap;
+}
+
+.status-badge {
+	display: inline-flex;
+	align-items: center;
+	padding: 6px 12px;
+	border-radius: 999px;
+	font-weight: 800;
+	font-size: 0.8rem;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	border: 1px solid transparent;
+}
+
+.status-badge.draft {
+	background: var(--warn-bg);
+	color: var(--warn-ink);
+	border-color: rgba(142, 91, 0, 0.25);
+}
+
+.status-badge.ready {
+	background: rgba(185, 239, 231, 0.92);
+	color: var(--accent-cool);
+	border-color: rgba(27, 128, 114, 0.25);
+}
+
+.status-badge.published {
+	background: var(--ok-bg);
+	color: var(--ok-ink);
+	border-color: rgba(22, 98, 70, 0.25);
+}
+
+.creator-nav {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.creator-nav a {
+	padding: 8px 10px;
+	border-radius: 10px;
+	border: 1px solid rgba(31, 26, 22, 0.2);
+	text-decoration: none;
+	font-weight: 700;
+	font-size: 0.85rem;
+	background: rgba(255, 255, 255, 0.72);
+}
+
+.creator-nav a.active {
+	background: rgba(27, 128, 114, 0.18);
+	border-color: rgba(27, 128, 114, 0.4);
+}
+
+.creator-card {
+	padding: 14px;
+	border-radius: 14px;
+	background: rgba(255, 255, 255, 0.66);
+	border: 1px solid var(--line-soft);
+}
+
+.field {
+	display: grid;
+	gap: 6px;
+	margin-bottom: 10px;
+}
+
+.text-area {
+	max-width: 100%;
+}
+
+.template-list {
+	display: grid;
+	gap: 8px;
+	margin-bottom: 12px;
+}
+
+.template-option {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+	padding: 10px;
+	border-radius: 10px;
+	border: 1px solid rgba(31, 26, 22, 0.18);
+	background: rgba(255, 255, 255, 0.75);
+}
+
+.template-option p {
+	margin: 4px 0 0;
+	color: var(--ink-500);
+}
+
+.validation-list {
+	margin-top: 10px;
+	padding: 10px;
+	border-radius: 10px;
+	background: rgba(255, 217, 209, 0.65);
+	border: 1px solid rgba(145, 34, 26, 0.25);
+	color: var(--bad-ink);
+}
+
+.validation-list ul {
+	margin: 8px 0 0;
+}
+
+.publish-ok {
+	margin-top: 10px;
+	padding: 10px;
+	border-radius: 10px;
+	background: rgba(212, 247, 233, 0.7);
+	border: 1px solid rgba(22, 98, 70, 0.24);
+	color: var(--ok-ink);
+	font-weight: 700;
+}
+
+.preview-card {
+	margin-top: 8px;
+	padding: 12px;
+	border-radius: 12px;
+	border: 1px solid rgba(31, 26, 22, 0.2);
+	background: linear-gradient(145deg, rgba(255, 255, 255, 0.96), rgba(248, 242, 236, 0.9));
+}
+
+.preview-card h4 {
+	margin: 0 0 8px;
+	font-size: 1.25rem;
+}
+
+.preview-meta {
+	display: grid;
+	gap: 3px;
+	margin-bottom: 10px;
+	color: var(--ink-500);
+	font-size: 0.92rem;
+}
+
+.publish-actions {
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.version-list ul {
+	list-style: none;
+	padding: 0;
+	margin: 8px 0 0;
+	display: grid;
+	gap: 8px;
+}
+
+.version-list li {
+	padding: 10px;
+	border-radius: 10px;
+	border: 1px solid rgba(31, 26, 22, 0.2);
+	background: rgba(255, 255, 255, 0.75);
+}
+
+.version-list li p {
+	margin: 6px 0 0;
+}
+
+.version-list li.active-version {
+	border-color: rgba(22, 98, 70, 0.35);
+	background: rgba(212, 247, 233, 0.68);
+}

--- a/src/lib/creator/store.ts
+++ b/src/lib/creator/store.ts
@@ -1,0 +1,91 @@
+import { writable } from 'svelte/store';
+import {
+    applyTemplate,
+    createEmptyDraft,
+    createEmptyPublishState,
+    deriveCreatorBadgeStatus,
+    loadCreatorState,
+    publishDraft,
+    saveCreatorState,
+    unpublish,
+    validateDraft,
+    type CreatorBadgeStatus,
+    type CreatorWorkspaceState,
+    type ValidationResult
+} from './storyBuilder';
+
+interface CreatorStore extends ReturnType<typeof writable<CreatorWorkspaceState>> {
+    initialize(): void;
+    setTemplate(templateId: string): void;
+    patchDraft(patch: Partial<CreatorWorkspaceState['draft']>): void;
+    publish(): void;
+    unpublish(): void;
+    getValidation(state: CreatorWorkspaceState): ValidationResult;
+    getBadgeStatus(state: CreatorWorkspaceState): CreatorBadgeStatus;
+}
+
+const initialState: CreatorWorkspaceState = {
+    draft: createEmptyDraft(),
+    publish: createEmptyPublishState()
+};
+
+function createCreatorStore(): CreatorStore {
+    const base = writable<CreatorWorkspaceState>(initialState);
+
+    const persist = (state: CreatorWorkspaceState): void => {
+        if (typeof window === 'undefined') return;
+        saveCreatorState(window.localStorage, state);
+    };
+
+    const updateAndPersist = (
+        updater: (state: CreatorWorkspaceState) => CreatorWorkspaceState
+    ): void => {
+        base.update((state) => {
+            const next = updater(state);
+            persist(next);
+            return next;
+        });
+    };
+
+    return {
+        ...base,
+        initialize: (): void => {
+            if (typeof window === 'undefined') return;
+            const loaded = loadCreatorState(window.localStorage);
+            base.set(loaded);
+        },
+        setTemplate: (templateId: string): void => {
+            updateAndPersist((state) => ({
+                ...state,
+                draft: applyTemplate(state.draft, templateId)
+            }));
+        },
+        patchDraft: (patch): void => {
+            updateAndPersist((state) => ({
+                ...state,
+                draft: {
+                    ...state.draft,
+                    ...patch,
+                    assets: Array.isArray(patch.assets)
+                        ? patch.assets.filter((asset): asset is string => typeof asset === 'string')
+                        : [...state.draft.assets],
+                    updatedAt: new Date().toISOString()
+                }
+            }));
+        },
+        publish: (): void => {
+            updateAndPersist((state) => {
+                const validation = validateDraft(state.draft);
+                if (!validation.isReady) return state;
+                return publishDraft(state);
+            });
+        },
+        unpublish: (): void => {
+            updateAndPersist((state) => unpublish(state));
+        },
+        getValidation: (state) => validateDraft(state.draft),
+        getBadgeStatus: (state) => deriveCreatorBadgeStatus(state)
+    };
+}
+
+export const creatorStore = createCreatorStore();

--- a/src/lib/creator/storyBuilder.ts
+++ b/src/lib/creator/storyBuilder.ts
@@ -1,0 +1,310 @@
+export interface CreatorDraft {
+    templateId: string;
+    title: string;
+    synopsis: string;
+    theme: string;
+    systemPrompt: string;
+    userPrompt: string;
+    assets: string[];
+    updatedAt: string;
+}
+
+export interface PublishedVersion {
+    version: number;
+    publishedAt: string;
+    snapshot: CreatorDraft;
+}
+
+export interface CreatorPublishState {
+    activeVersion: number | null;
+    versions: PublishedVersion[];
+}
+
+export interface CreatorWorkspaceState {
+    draft: CreatorDraft;
+    publish: CreatorPublishState;
+}
+
+export interface ValidationResult {
+    isReady: boolean;
+    errors: string[];
+}
+
+export type CreatorBadgeStatus = 'Draft' | 'Ready' | 'Published';
+
+const DRAFT_KEY = 'nv-creator-draft-v1';
+const PUBLISH_KEY = 'nv-creator-publish-v1';
+
+const STORY_TEMPLATES = {
+    blank: {
+        title: 'Untitled Story',
+        synopsis: '',
+        theme: '',
+        systemPrompt: '',
+        userPrompt: '',
+        assets: []
+    },
+    comeback: {
+        title: 'Night Shift Comeback',
+        synopsis:
+            "Sydney faces one long motel shift and has to decide whether to keep absorbing everyone else's chaos or finally redirect the work.",
+        theme: 'Invisible labor, emotional debt, and the cost of staying available.',
+        systemPrompt:
+            'Keep scenes sensory and grounded. Every choice must force a tradeoff between short-term peace and long-term self-respect.',
+        userPrompt:
+            'Generate an opening scene in second person with 2-3 tense choices. Track boundaries and emotional carryover.',
+        assets: ['hotel_room', 'sydney_phone_anxious']
+    },
+    reckoning: {
+        title: 'Motel Reckoning',
+        synopsis:
+            'After a week of escalating favors, Sydney reaches the point where one small request could break the entire dynamic.',
+        theme: 'Boundaries, manipulation, and choosing visible costs over hidden ones.',
+        systemPrompt:
+            'Write concise present-tense scenes with motive/consequence clarity. Keep prose cinematic and emotionally specific.',
+        userPrompt:
+            'Build scenes where each choice changes trust, pressure, or leverage. Endings should feel earned, not abrupt.',
+        assets: ['motel_exterior', 'sydney_window_dawn']
+    }
+} as const;
+
+type TemplateId = keyof typeof STORY_TEMPLATES;
+
+function nowIso(): string {
+    return new Date().toISOString();
+}
+
+export function createEmptyDraft(): CreatorDraft {
+    return {
+        templateId: 'blank',
+        title: STORY_TEMPLATES.blank.title,
+        synopsis: STORY_TEMPLATES.blank.synopsis,
+        theme: STORY_TEMPLATES.blank.theme,
+        systemPrompt: STORY_TEMPLATES.blank.systemPrompt,
+        userPrompt: STORY_TEMPLATES.blank.userPrompt,
+        assets: [...STORY_TEMPLATES.blank.assets],
+        updatedAt: nowIso()
+    };
+}
+
+export function createEmptyPublishState(): CreatorPublishState {
+    return {
+        activeVersion: null,
+        versions: []
+    };
+}
+
+function safeParse<T>(raw: string | null, fallback: T): T {
+    if (!raw) return fallback;
+    try {
+        const parsed = JSON.parse(raw) as T;
+        return parsed ?? fallback;
+    } catch {
+        return fallback;
+    }
+}
+
+function normalizeDraft(input: Partial<CreatorDraft> | null | undefined): CreatorDraft {
+    const base = createEmptyDraft();
+    if (!input || typeof input !== 'object') return base;
+
+    return {
+        templateId: typeof input.templateId === 'string' ? input.templateId : base.templateId,
+        title: typeof input.title === 'string' ? input.title : base.title,
+        synopsis: typeof input.synopsis === 'string' ? input.synopsis : base.synopsis,
+        theme: typeof input.theme === 'string' ? input.theme : base.theme,
+        systemPrompt:
+            typeof input.systemPrompt === 'string' ? input.systemPrompt : base.systemPrompt,
+        userPrompt: typeof input.userPrompt === 'string' ? input.userPrompt : base.userPrompt,
+        assets: Array.isArray(input.assets)
+            ? input.assets.filter((asset): asset is string => typeof asset === 'string')
+            : base.assets,
+        updatedAt: typeof input.updatedAt === 'string' ? input.updatedAt : base.updatedAt
+    };
+}
+
+function normalizePublishState(
+    input: Partial<CreatorPublishState> | null | undefined
+): CreatorPublishState {
+    const base = createEmptyPublishState();
+    if (!input || typeof input !== 'object') return base;
+
+    const versions = Array.isArray(input.versions)
+        ? input.versions
+              .filter(
+                  (version): version is PublishedVersion =>
+                      typeof version === 'object' &&
+                      version !== null &&
+                      typeof version.version === 'number' &&
+                      typeof version.publishedAt === 'string' &&
+                      typeof version.snapshot === 'object' &&
+                      version.snapshot !== null
+              )
+              .map((version) => ({
+                  ...version,
+                  snapshot: normalizeDraft(version.snapshot)
+              }))
+        : base.versions;
+
+    const activeVersion =
+        typeof input.activeVersion === 'number' &&
+        versions.some((version) => version.version === input.activeVersion)
+            ? input.activeVersion
+            : null;
+
+    return {
+        activeVersion,
+        versions
+    };
+}
+
+function draftFingerprint(draft: CreatorDraft): string {
+    return JSON.stringify({
+        title: draft.title.trim(),
+        synopsis: draft.synopsis.trim(),
+        theme: draft.theme.trim(),
+        systemPrompt: draft.systemPrompt.trim(),
+        userPrompt: draft.userPrompt.trim(),
+        assets: draft.assets.map((asset) => asset.trim()).filter(Boolean)
+    });
+}
+
+export function validateDraft(draft: CreatorDraft): ValidationResult {
+    const errors: string[] = [];
+    if (draft.title.trim().length < 5) errors.push('Title must be at least 5 characters.');
+    if (draft.synopsis.trim().length < 30) errors.push('Synopsis must be at least 30 characters.');
+    if (draft.theme.trim().length < 10) errors.push('Theme must be at least 10 characters.');
+    if (draft.systemPrompt.trim().length < 30) {
+        errors.push('System prompt must be at least 30 characters.');
+    }
+    if (draft.userPrompt.trim().length < 30) {
+        errors.push('User prompt must be at least 30 characters.');
+    }
+    if (draft.assets.length === 0) errors.push('Add at least one visual asset key.');
+
+    return {
+        isReady: errors.length === 0,
+        errors
+    };
+}
+
+export function deriveCreatorBadgeStatus(state: CreatorWorkspaceState): CreatorBadgeStatus {
+    const validation = validateDraft(state.draft);
+    if (!validation.isReady) return 'Draft';
+
+    const activeVersion = state.publish.versions.find(
+        (version) => version.version === state.publish.activeVersion
+    );
+    if (!activeVersion) return 'Ready';
+
+    return draftFingerprint(state.draft) === draftFingerprint(activeVersion.snapshot)
+        ? 'Published'
+        : 'Ready';
+}
+
+export function listTemplateOptions(): Array<{ id: string; label: string; summary: string }> {
+    return [
+        {
+            id: 'blank',
+            label: 'Blank',
+            summary: 'Start from scratch with empty metadata and prompt fields.'
+        },
+        {
+            id: 'comeback',
+            label: 'Night Shift Comeback',
+            summary: 'Grounded pressure-cooker template focused on invisible labor tradeoffs.'
+        },
+        {
+            id: 'reckoning',
+            label: 'Motel Reckoning',
+            summary: 'Escalation-first template for boundary collapse and recovery arcs.'
+        }
+    ];
+}
+
+export function applyTemplate(draft: CreatorDraft, templateId: string): CreatorDraft {
+    const template =
+        STORY_TEMPLATES[(templateId as TemplateId) ?? 'blank'] ?? STORY_TEMPLATES.blank;
+    return {
+        templateId,
+        title: template.title,
+        synopsis: template.synopsis,
+        theme: template.theme,
+        systemPrompt: template.systemPrompt,
+        userPrompt: template.userPrompt,
+        assets: [...template.assets],
+        updatedAt: nowIso()
+    };
+}
+
+export function publishDraft(state: CreatorWorkspaceState): CreatorWorkspaceState {
+    const nextVersionNumber = state.publish.versions.length
+        ? Math.max(...state.publish.versions.map((version) => version.version)) + 1
+        : 1;
+
+    const version: PublishedVersion = {
+        version: nextVersionNumber,
+        publishedAt: nowIso(),
+        snapshot: {
+            ...state.draft,
+            assets: [...state.draft.assets],
+            updatedAt: nowIso()
+        }
+    };
+
+    return {
+        draft: {
+            ...state.draft,
+            assets: [...state.draft.assets]
+        },
+        publish: {
+            activeVersion: version.version,
+            versions: [version, ...state.publish.versions]
+        }
+    };
+}
+
+export function unpublish(state: CreatorWorkspaceState): CreatorWorkspaceState {
+    return {
+        draft: {
+            ...state.draft,
+            assets: [...state.draft.assets]
+        },
+        publish: {
+            ...state.publish,
+            activeVersion: null
+        }
+    };
+}
+
+export function loadCreatorState(storage: Storage | null | undefined): CreatorWorkspaceState {
+    let draftRaw: string | null = null;
+    let publishRaw: string | null = null;
+
+    try {
+        draftRaw = storage?.getItem(DRAFT_KEY) ?? null;
+        publishRaw = storage?.getItem(PUBLISH_KEY) ?? null;
+    } catch {
+        return {
+            draft: createEmptyDraft(),
+            publish: createEmptyPublishState()
+        };
+    }
+
+    const draft = normalizeDraft(safeParse<CreatorDraft | null>(draftRaw, null));
+    const publish = normalizePublishState(safeParse<CreatorPublishState | null>(publishRaw, null));
+    return { draft, publish };
+}
+
+export function saveCreatorState(
+    storage: Storage | null | undefined,
+    state: CreatorWorkspaceState
+): void {
+    if (!storage) return;
+    try {
+        storage.setItem(DRAFT_KEY, JSON.stringify(state.draft));
+        storage.setItem(PUBLISH_KEY, JSON.stringify(state.publish));
+    } catch {
+        // Silent fail keeps creator flow usable even with blocked storage.
+    }
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -22,6 +22,7 @@
 		<nav class="top-nav" aria-label="Primary navigation">
 			<a href="/" class:active={$page.url.pathname === '/'}>Home</a>
 			<a href="/play" class:active={$page.url.pathname === '/play'}>Play</a>
+			<a href="/create" class:active={$page.url.pathname.startsWith('/create')}>Create</a>
 			<a href="/settings" class:active={$page.url.pathname === '/settings'}>Settings</a>
 			<a href="/ending" class:active={$page.url.pathname === '/ending'}>Ending</a>
 			<a href="/debug" class:active={$page.url.pathname === '/debug'}>Debug</a>

--- a/src/routes/create/+layout.svelte
+++ b/src/routes/create/+layout.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import { onDestroy, onMount } from 'svelte';
+	import { page } from '$app/stores';
+	import { creatorStore } from '$lib/creator/store';
+	import type { CreatorWorkspaceState } from '$lib/creator/storyBuilder';
+
+	let state: CreatorWorkspaceState | null = null;
+
+	const unsubscribe = creatorStore.subscribe((value) => {
+		state = value;
+	});
+
+	onMount(() => {
+		creatorStore.initialize();
+	});
+
+	onDestroy(() => {
+		unsubscribe();
+	});
+
+	$: badge = state ? creatorStore.getBadgeStatus(state) : 'Draft';
+	$: badgeClass = badge.toLowerCase();
+</script>
+
+<section class="creator-shell" aria-live="polite">
+	<header class="creator-header">
+		<div>
+			<h2>Creator Workspace</h2>
+			<p class="lede">Build safely in draft, preview your flow, and publish only validated versions.</p>
+		</div>
+		<span class={`status-badge ${badgeClass}`}>{badge}</span>
+	</header>
+
+	<nav class="creator-nav" aria-label="Creator navigation">
+		<a href="/create/template" class:active={$page.url.pathname === '/create/template'}>1. Template</a>
+		<a href="/create/editor" class:active={$page.url.pathname === '/create/editor'}>2. Edit</a>
+		<a href="/create/preview" class:active={$page.url.pathname === '/create/preview'}>3. Preview</a>
+		<a href="/create/publish" class:active={$page.url.pathname === '/create/publish'}>4. Publish</a>
+	</nav>
+
+	<slot />
+</section>

--- a/src/routes/create/+page.svelte
+++ b/src/routes/create/+page.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { onMount } from 'svelte';
+
+	onMount(() => {
+		void goto('/create/template', { replaceState: true });
+	});
+</script>
+
+<p class="hint">Redirecting to creator templates...</p>

--- a/src/routes/create/editor/+page.svelte
+++ b/src/routes/create/editor/+page.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	import { creatorStore } from '$lib/creator/store';
+	import type { CreatorWorkspaceState } from '$lib/creator/storyBuilder';
+
+	let state: CreatorWorkspaceState | null = null;
+
+	const unsubscribe = creatorStore.subscribe((value) => {
+		state = value;
+	});
+
+	$: validation = state ? creatorStore.getValidation(state) : { isReady: false, errors: [] as string[] };
+
+	onDestroy(() => {
+		unsubscribe();
+	});
+
+	function updateField(field: keyof CreatorWorkspaceState['draft'], value: string): void {
+		creatorStore.patchDraft({ [field]: value });
+	}
+
+	function updateAssets(value: string): void {
+		const assets = value
+			.split(',')
+			.map((item) => item.trim())
+			.filter(Boolean);
+		creatorStore.patchDraft({ assets });
+	}
+</script>
+
+{#if state}
+	<section class="creator-card">
+		<h3>Edit metadata, prompts, and assets</h3>
+		<p class="hint">Draft saves automatically in local storage and is isolated from publish history.</p>
+
+		<label class="field">
+			<span>Story title</span>
+			<input
+				class="text-input"
+				value={state.draft.title}
+				on:input={(event) => updateField('title', (event.currentTarget as HTMLInputElement).value)}
+			/>
+		</label>
+
+		<label class="field">
+			<span>Synopsis</span>
+			<textarea
+				rows="3"
+				class="text-input text-area"
+				value={state.draft.synopsis}
+				on:input={(event) => updateField('synopsis', (event.currentTarget as HTMLTextAreaElement).value)}
+			></textarea>
+		</label>
+
+		<label class="field">
+			<span>Theme</span>
+			<input
+				class="text-input"
+				value={state.draft.theme}
+				on:input={(event) => updateField('theme', (event.currentTarget as HTMLInputElement).value)}
+			/>
+		</label>
+
+		<label class="field">
+			<span>System prompt</span>
+			<textarea
+				rows="4"
+				class="text-input text-area"
+				value={state.draft.systemPrompt}
+				on:input={(event) => updateField('systemPrompt', (event.currentTarget as HTMLTextAreaElement).value)}
+			></textarea>
+		</label>
+
+		<label class="field">
+			<span>User prompt</span>
+			<textarea
+				rows="4"
+				class="text-input text-area"
+				value={state.draft.userPrompt}
+				on:input={(event) => updateField('userPrompt', (event.currentTarget as HTMLTextAreaElement).value)}
+			></textarea>
+		</label>
+
+		<label class="field">
+			<span>Asset keys (comma separated)</span>
+			<input
+				class="text-input"
+				value={state.draft.assets.join(', ')}
+				on:input={(event) => updateAssets((event.currentTarget as HTMLInputElement).value)}
+			/>
+		</label>
+
+		{#if validation.errors.length > 0}
+			<div class="validation-list" role="status">
+				<strong>Draft requirements before publish:</strong>
+				<ul>
+					{#each validation.errors as error}
+						<li>{error}</li>
+					{/each}
+				</ul>
+			</div>
+		{:else}
+			<p class="publish-ok">All validation checks pass. Draft is publish-ready.</p>
+		{/if}
+	</section>
+{/if}

--- a/src/routes/create/preview/+page.svelte
+++ b/src/routes/create/preview/+page.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	import { creatorStore } from '$lib/creator/store';
+	import type { CreatorWorkspaceState } from '$lib/creator/storyBuilder';
+
+	let state: CreatorWorkspaceState | null = null;
+	const unsubscribe = creatorStore.subscribe((value) => {
+		state = value;
+	});
+
+	$: validation = state ? creatorStore.getValidation(state) : { isReady: false, errors: [] as string[] };
+
+	onDestroy(() => {
+		unsubscribe();
+	});
+</script>
+
+<svelte:head>
+	<title>Creator Preview · No Vacancies</title>
+</svelte:head>
+
+{#if state}
+	<section class="creator-card">
+		<h3>Preview play mode</h3>
+		<p class="hint">This preview mirrors what players would enter on a new run before you publish.</p>
+
+		<article class="preview-card">
+			<p class="eyebrow">PREVIEW OPENING</p>
+			<h4>{state.draft.title}</h4>
+			<p>{state.draft.synopsis || 'Add a synopsis to see your opening context.'}</p>
+			<div class="preview-meta">
+				<span><strong>Theme:</strong> {state.draft.theme || '—'}</span>
+				<span><strong>Assets:</strong> {state.draft.assets.join(', ') || '—'}</span>
+			</div>
+			<ol>
+				<li>Work the phones before anyone wakes up.</li>
+				<li>Wake Oswaldo and force an answer now.</li>
+				<li>Step outside and call your own shot.</li>
+			</ol>
+		</article>
+
+		{#if !validation.isReady}
+			<p class="hint">Preview available, but publish remains blocked until validation is clean.</p>
+		{/if}
+	</section>
+{/if}

--- a/src/routes/create/publish/+page.svelte
+++ b/src/routes/create/publish/+page.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	import { creatorStore } from '$lib/creator/store';
+	import type { CreatorWorkspaceState } from '$lib/creator/storyBuilder';
+
+	let state: CreatorWorkspaceState | null = null;
+	const unsubscribe = creatorStore.subscribe((value) => {
+		state = value;
+	});
+
+	$: validation = state ? creatorStore.getValidation(state) : { isReady: false, errors: [] as string[] };
+
+	onDestroy(() => {
+		unsubscribe();
+	});
+
+	function publish(): void {
+		creatorStore.publish();
+	}
+
+	function unpublish(): void {
+		creatorStore.unpublish();
+	}
+</script>
+
+{#if state}
+	<section class="creator-card">
+		<h3>Publish / unpublish versions</h3>
+		<p class="hint">Publishing snapshots the current draft as an immutable version for play mode rollout.</p>
+
+		<div class="publish-actions">
+			<button class="btn btn-primary" on:click={publish} disabled={!validation.isReady}>Publish New Version</button>
+			<button class="btn btn-secondary" on:click={unpublish} disabled={state.publish.activeVersion === null}
+				>Unpublish Active Version</button
+			>
+		</div>
+
+		{#if validation.errors.length > 0}
+			<div class="validation-list" role="alert">
+				<strong>Cannot publish yet:</strong>
+				<ul>
+					{#each validation.errors as error}
+						<li>{error}</li>
+					{/each}
+				</ul>
+			</div>
+		{/if}
+
+		<div class="version-list">
+			<h4>Version history</h4>
+			{#if state.publish.versions.length === 0}
+				<p class="hint">No published versions yet.</p>
+			{:else}
+				<ul>
+					{#each state.publish.versions as version}
+						<li class:active-version={state.publish.activeVersion === version.version}>
+							<div>
+								<strong>v{version.version}</strong>
+								<span> · {new Date(version.publishedAt).toLocaleString()}</span>
+							</div>
+							<p>{version.snapshot.title}</p>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
+	</section>
+{/if}

--- a/src/routes/create/template/+page.svelte
+++ b/src/routes/create/template/+page.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import { creatorStore } from '$lib/creator/store';
+	import { listTemplateOptions } from '$lib/creator/storyBuilder';
+
+	const templates = listTemplateOptions();
+	let selected = 'blank';
+
+	function apply(): void {
+		creatorStore.setTemplate(selected);
+	}
+</script>
+
+<section class="creator-card">
+	<h3>Start from a template</h3>
+	<p class="hint">Templates overwrite your current draft fields, but never touch published versions.</p>
+
+	<div class="template-list" role="radiogroup" aria-label="Story template choices">
+		{#each templates as template}
+			<label class="template-option">
+				<input type="radio" name="template" bind:group={selected} value={template.id} />
+				<div>
+					<strong>{template.label}</strong>
+					<p>{template.summary}</p>
+				</div>
+			</label>
+		{/each}
+	</div>
+
+	<button class="btn btn-primary" on:click={apply}>Apply Template to Draft</button>
+</section>

--- a/tests/unit/creatorState.spec.ts
+++ b/tests/unit/creatorState.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from '@playwright/test';
+import {
+    createEmptyDraft,
+    createEmptyPublishState,
+    deriveCreatorBadgeStatus,
+    publishDraft,
+    unpublish,
+    validateDraft,
+    type CreatorWorkspaceState
+} from '../../src/lib/creator/storyBuilder';
+
+function readyState(): CreatorWorkspaceState {
+    return {
+        draft: {
+            ...createEmptyDraft(),
+            title: 'Boundary Shift',
+            synopsis:
+                "Sydney has one night to decide if she keeps patching everyone else's emergencies or lets the fallout land where it belongs.",
+            theme: 'Invisible labor and boundary debt',
+            systemPrompt:
+                'Write grounded second-person scenes with motive and consequence clarity. Keep every choice tense and costly.',
+            userPrompt:
+                'Generate 2-3 choices with visible tradeoffs. Carry boundary pressure and relational consequences across turns.',
+            assets: ['hotel_room']
+        },
+        publish: createEmptyPublishState()
+    };
+}
+
+test('validation blocks publishing when draft fields are incomplete', () => {
+    const state: CreatorWorkspaceState = {
+        draft: createEmptyDraft(),
+        publish: createEmptyPublishState()
+    };
+    const result = validateDraft(state.draft);
+
+    expect(result.isReady).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(deriveCreatorBadgeStatus(state)).toBe('Draft');
+});
+
+test('publishing creates a version snapshot without mutating draft', () => {
+    const state = readyState();
+    const published = publishDraft(state);
+
+    expect(published.publish.activeVersion).toBe(1);
+    expect(published.publish.versions).toHaveLength(1);
+    expect(published.publish.versions[0]?.snapshot.title).toBe(state.draft.title);
+    expect(published.draft.title).toBe(state.draft.title);
+    expect(deriveCreatorBadgeStatus(published)).toBe('Published');
+});
+
+test('unpublish keeps history but clears active version', () => {
+    const published = publishDraft(readyState());
+    const unpublished = unpublish(published);
+
+    expect(unpublished.publish.activeVersion).toBeNull();
+    expect(unpublished.publish.versions).toHaveLength(1);
+    expect(deriveCreatorBadgeStatus(unpublished)).toBe('Ready');
+});


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992f1e733b8832084392c99a74b147f)

## Summary by Sourcery

Introduce a new creator workspace with a guided multi-step flow for drafting, previewing, and publishing narrative content, backed by persisted local state and visible status badges.

New Features:
- Add a `/create/*` route group providing a four-step creator workflow: template selection, draft editing, preview, and publish/unpublish controls.
- Persist creator draft and published version history separately in local storage so edits are decoupled from deployed content.
- Surface Draft/Ready/Published status badges and validation messaging to indicate publish readiness and prevent incomplete releases.

Enhancements:
- Extend the primary layout navigation to expose the new Creator workspace entry point.
- Add dedicated styling for creator workspace shells, cards, navigation, status badges, validation panels, previews, and version history lists.

Tests:
- Add unit tests covering creator draft validation, publish snapshot behavior, unpublish behavior, and badge status transitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a comprehensive creator workflow with template selection, draft editing, live preview, and publishing capabilities.
  * Added draft and publish state management with validation status indicators (Draft, Ready, Published).
  * Implemented local storage persistence for creator workspace data.

* **Documentation**
  * Updated README with creator workflow documentation, play UX enhancements, and runtime configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->