### PR TITLE
Add image pipeline lifecycle, retries, cache reuse, and creator controls

### DIFF
--- a/AI_LESSONS_LEARNED.md
+++ b/AI_LESSONS_LEARNED.md
@@ -240,3 +240,8 @@
 
 **Insight:** Deleting regex taste filters improves reliability, but voice can still drift if recovery prompts are less strict than primary prompts.
 **Lesson:** Keep voice constraints in both the system prompt and the recovery prompt (same banned-phrase policy, same rewrite rule), then verify with deterministic quality-floor tests.
+
+## 36. Image Generation Reliability Needs Explicit Lifecycle State
+
+**Insight:** A single "generate image" call hides too much operational reality during demos (queueing, retries, cache reuse, creator decision state), making failures hard to triage quickly.
+**Lesson:** Treat image generation as a tracked request lifecycle (`queued` → `running` → `success`/`failed`) with bounded retries and reason codes, and expose that state in both creator UI and debug/readiness surfaces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+- **Image Pipeline Orchestration:** Rebuilt `/api/image` around request-state records (`queued`/`running`/`success`/`failed`), bounded retry tracking with reason codes, cache-key reuse, and explicit creator actions (`generate`, `regenerate`, `accept`, `reject`, `fallback_to_static`) with guardrail-safe messaging (`src/routes/api/image/+server.ts`, `src/lib/server/ai/imagePipeline.ts`, `src/lib/server/ai/providers/grok.ts`, `src/lib/client/imageCreatorState.ts`, `src/routes/settings/+page.svelte`).
+- **Demo Ops Visibility for Images:** Added image pipeline instrumentation to readiness scoring and debug UI so operators can inspect in-flight work, cache state, and recent request outcomes during demo prep (`src/routes/api/demo/readiness/+server.ts`, `src/routes/debug/+page.svelte`, `tests/e2e/demo-reliability.spec.js`).
+
 - **Prompt Voice-Safety Reinforcement:** Added explicit forbidden-phrasing guidance to the main system prompt and recovery prompt path so didactic/therapy-summary drift is redirected to behavior+motive+consequence framing (`src/lib/server/ai/narrative.ts`).
 - **Narrative Prompt Encoding Cleanup:** Replaced mojibake-affected prompt markers/punctuation with ASCII-safe wording in active narrative prompt assets (`src/lib/server/ai/narrative.ts`, `docs/NARRATIVE_DRIFT_REMAINING_WORK_2026-02-13.md`).
 - **Context/Transition Test Hardening:** Added deterministic unit coverage that proves context budgeting trims older summaries before recent prose and that transition bridges emit mapped lines only when thread deltas exist (`tests/unit/contextBudget.spec.ts`, `tests/unit/transitionBridge.spec.ts`).

--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ Demo readiness UX:
 - Home route (`/`) now includes a "Demo Readiness" progress dashboard backed by `/api/demo/readiness`.
 - Score/checks are runtime-derived (provider mode, key presence, outage mode, probe state) so you can quickly gauge demo readiness.
 - Debug route (`/debug`) shows persisted runtime/client/API error events to speed up playthrough troubleshooting.
+- Image pipeline status (in-flight count, cache size, recent request outcomes) is exposed in both `/debug` and readiness checks for fast operator triage.
 
 Play UX:
 - `/play` uses a command-deck layout with clearer scene hierarchy, arc progress meter, and keyboard choice shortcuts (`1`, `2`, `3`) for faster turn selection.
 - `/play` also exposes quick utility controls (restart current run, jump to `/debug`) plus scene/arc/mood chips so operators can triage runs faster during demos.
+- `/settings` now includes a Creator Image Pipeline panel with generation state, bounded-retry history, cache key visibility, and creator actions (regenerate/accept/reject/fallback-to-static).
 
 ## Run
 

--- a/src/lib/client/imageCreatorState.ts
+++ b/src/lib/client/imageCreatorState.ts
@@ -1,0 +1,120 @@
+import { writable } from 'svelte/store';
+import { appendDebugError } from '$lib/debug/errorLog';
+import type {
+	ImagePipelineSummary,
+	ImageRequestRecord,
+	CreatorImageAction
+} from '$lib/server/ai/imagePipeline';
+
+interface ImageApiSuccess {
+	request?: ImageRequestRecord;
+	status?: ImagePipelineSummary;
+	error?: string;
+}
+
+export interface ImageCreatorState {
+	prompt: string;
+	activeRequest: ImageRequestRecord | null;
+	status: ImagePipelineSummary | null;
+	isWorking: boolean;
+	error: string;
+}
+
+const initialState: ImageCreatorState = {
+	prompt: '',
+	activeRequest: null,
+	status: null,
+	isWorking: false,
+	error: ''
+};
+
+function mapImageError(raw: unknown): string {
+	const text = raw instanceof Error ? raw.message : String(raw ?? 'Image request failed');
+	if (/guardrail/i.test(text)) return 'Image prompt blocked by safety guardrails. Please revise and retry.';
+	if (/rate|429/i.test(text)) return 'Image generation is temporarily rate-limited. Try again shortly.';
+	if (/timed out|timeout/i.test(text)) return 'Image generation timed out. Please retry.';
+	return text;
+}
+
+async function callImageApi(payload: Record<string, unknown>): Promise<ImageApiSuccess> {
+	const response = await fetch('/api/image', {
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify(payload)
+	});
+	const body = (await response.json().catch(() => ({}))) as ImageApiSuccess;
+	if (!response.ok) {
+		throw new Error(body.error || `image request failed (${response.status})`);
+	}
+	return body;
+}
+
+function normalizeAction(action: CreatorImageAction): CreatorImageAction {
+	if (action === 'generate' || action === 'regenerate' || action === 'accept' || action === 'reject' || action === 'fallback_to_static') {
+		return action;
+	}
+	return 'generate';
+}
+
+function createImageCreatorStore() {
+	const { subscribe, update } = writable<ImageCreatorState>(initialState);
+
+	return {
+		subscribe,
+		setPrompt(prompt: string): void {
+			update((state) => ({ ...state, prompt }));
+		},
+		clearError(): void {
+			update((state) => ({ ...state, error: '' }));
+		},
+		async refreshStatus(): Promise<void> {
+			try {
+				const response = await fetch('/api/image');
+				if (!response.ok) throw new Error(`Failed to load image status (${response.status})`);
+				const body = (await response.json()) as { status?: ImagePipelineSummary };
+				update((state) => ({ ...state, status: body.status ?? null }));
+			} catch (error) {
+				const message = mapImageError(error);
+				appendDebugError({
+					scope: 'image.status',
+					message,
+					details: { raw: error instanceof Error ? error.message : String(error) }
+				});
+				update((state) => ({ ...state, error: message }));
+			}
+		},
+		async triggerAction(actionInput: CreatorImageAction, overrides: { prompt?: string; requestId?: string } = {}): Promise<void> {
+			const action = normalizeAction(actionInput);
+			update((state) => ({ ...state, isWorking: true, error: '' }));
+			try {
+				const payload: Record<string, unknown> = { action };
+				if (action === 'generate' || action === 'regenerate') {
+					payload.prompt = (overrides.prompt ?? '').trim();
+				} else {
+					payload.requestId = overrides.requestId;
+				}
+				const body = await callImageApi(payload);
+				update((state) => ({
+					...state,
+					activeRequest: body.request ?? state.activeRequest,
+					status: body.status ?? state.status,
+					isWorking: false,
+					error: ''
+				}));
+			} catch (error) {
+				const message = mapImageError(error);
+				appendDebugError({
+					scope: 'image.action',
+					message,
+					details: {
+						action,
+						raw: error instanceof Error ? error.message : String(error)
+					}
+				});
+				update((state) => ({ ...state, isWorking: false, error: message }));
+			}
+		}
+	};
+}
+
+export const imageCreatorStore = createImageCreatorStore();

--- a/src/lib/server/ai/imagePipeline.ts
+++ b/src/lib/server/ai/imagePipeline.ts
@@ -1,0 +1,390 @@
+import { loadAiConfig, type AiConfig } from '$lib/server/ai/config';
+import { createProviderRegistry, selectImageProvider } from '$lib/server/ai/providers';
+import { AiProviderError, type AiErrorCode, type GeneratedImage } from '$lib/server/ai/provider.interface';
+
+export type ImageGenerationState = 'queued' | 'running' | 'success' | 'failed';
+export type CreatorImageAction =
+	| 'generate'
+	| 'regenerate'
+	| 'accept'
+	| 'reject'
+	| 'fallback_to_static';
+
+export type ImageRetryReasonCode =
+	| AiErrorCode
+	| 'network_error'
+	| 'aborted'
+	| 'invalid_prompt'
+	| 'image_disabled';
+
+export interface ImageRetryAttempt {
+	attempt: number;
+	reasonCode: ImageRetryReasonCode;
+	retryable: boolean;
+	message: string;
+	timestamp: string;
+}
+
+export interface ImageRequestRecord {
+	requestId: string;
+	prompt: string;
+	cacheKey: string;
+	status: ImageGenerationState;
+	action: CreatorImageAction;
+	createdAt: string;
+	updatedAt: string;
+	retry: {
+		attemptCount: number;
+		maxAttempts: number;
+		reasons: ImageRetryAttempt[];
+	};
+	result: GeneratedImage | null;
+	error: {
+		reasonCode: ImageRetryReasonCode;
+		message: string;
+	} | null;
+	decision: 'accepted' | 'rejected' | 'fallback_to_static' | null;
+	cacheHit: boolean;
+}
+
+export interface ImagePipelineSummary {
+	inFlight: number;
+	totalRequests: number;
+	successCount: number;
+	failedCount: number;
+	cacheEntries: number;
+	lastUpdatedAt: string | null;
+	recentRequests: ImageRequestRecord[];
+	configError?: string | null;
+}
+
+interface ImagePipelineDependencies {
+	config?: AiConfig;
+	generateImage?: (prompt: string) => Promise<GeneratedImage>;
+	now?: () => number;
+}
+
+const MAX_HISTORY = 120;
+
+function nextRequestId(now: number): string {
+	return `img_${now}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function toIso(now: number): string {
+	return new Date(now).toISOString();
+}
+
+function hashPrompt(value: string): string {
+	let hash = 0;
+	for (let i = 0; i < value.length; i += 1) {
+		hash = (hash * 31 + value.charCodeAt(i)) >>> 0;
+	}
+	return hash.toString(16).padStart(8, '0');
+}
+
+export function buildImageCacheKey(prompt: string, modelHint: string): string {
+	const normalizedPrompt = prompt.trim().replace(/\s+/g, ' ').toLowerCase();
+	return `img:${modelHint}:${hashPrompt(normalizedPrompt)}`;
+}
+
+function mapReasonCode(error: unknown): ImageRetryReasonCode {
+	if (error instanceof AiProviderError) return error.code;
+	if (error instanceof Error && error.name === 'AbortError') return 'aborted';
+	if (error instanceof Error && /network|fetch|econn|enotfound/i.test(error.message)) {
+		return 'network_error';
+	}
+	return 'unknown';
+}
+
+function isRetryable(error: unknown): boolean {
+	if (error instanceof AiProviderError) return error.retryable;
+	if (error instanceof Error && error.name === 'AbortError') return true;
+	return false;
+}
+
+export function toGuardrailSafeImageMessage(reasonCode: ImageRetryReasonCode): string {
+	switch (reasonCode) {
+		case 'guardrail':
+			return 'Image request blocked by safety guardrails. Adjust the prompt and try again.';
+		case 'auth':
+			return 'Image generation is unavailable due to provider authentication issues.';
+		case 'rate_limit':
+			return 'Image generation is temporarily rate-limited. Try again shortly.';
+		case 'timeout':
+		case 'aborted':
+			return 'Image generation timed out before completion. Try again.';
+		case 'provider_down':
+			return 'Image generation provider is unavailable right now.';
+		case 'invalid_response':
+			return 'Image provider returned an invalid response. Please retry.';
+		case 'image_disabled':
+			return 'Dynamic image generation is disabled. Use fallback-to-static.';
+		case 'network_error':
+			return 'Image generation could not reach the provider network endpoint.';
+		case 'invalid_prompt':
+			return 'Image prompt is required.';
+		default:
+			return 'Image generation failed due to an unexpected provider error.';
+	}
+}
+
+export class ImagePipeline {
+	private readonly config: AiConfig;
+	private readonly configError: string | null;
+	private readonly generateImage: (prompt: string) => Promise<GeneratedImage>;
+	private readonly now: () => number;
+	private readonly requests = new Map<string, ImageRequestRecord>();
+	private readonly requestOrder: string[] = [];
+	private readonly cache = new Map<string, string>();
+
+	constructor(deps: ImagePipelineDependencies = {}) {
+		if (deps.config) {
+			this.config = deps.config;
+			this.configError = null;
+		} else {
+			try {
+				this.config = loadAiConfig();
+				this.configError = null;
+			} catch (error) {
+				this.config = {
+					provider: 'grok',
+					enableGrokText: true,
+					enableGrokImages: false,
+					enableProviderProbe: false,
+					aiAuthBypass: false,
+					outageMode: 'hard_fail',
+					xaiApiKey: '',
+					grokTextModel: 'grok-4-1-fast-reasoning',
+					grokImageModel: 'grok-imagine-image',
+					maxOutputTokens: 1800,
+					requestTimeoutMs: 20000,
+					maxRetries: 2,
+					retryBackoffMs: [400, 1200]
+				};
+				this.configError = error instanceof Error ? error.message : 'Invalid AI config';
+			}
+		}
+		if (deps.generateImage) {
+			this.generateImage = deps.generateImage;
+		} else {
+			this.generateImage = async (prompt: string) => {
+				const provider = selectImageProvider(this.config, createProviderRegistry(this.config));
+				if (!provider.generateImage) {
+					throw new Error('Selected image provider does not implement generateImage');
+				}
+				return provider.generateImage({ prompt });
+			};
+		}
+		this.now = deps.now ?? (() => Date.now());
+	}
+
+	private modelHint(): string {
+		return this.config.grokImageModel || 'image-model';
+	}
+
+	private touchRecord(record: ImageRequestRecord): void {
+		record.updatedAt = toIso(this.now());
+	}
+
+	private addRecord(record: ImageRequestRecord): void {
+		this.requests.set(record.requestId, record);
+		this.requestOrder.unshift(record.requestId);
+		if (this.requestOrder.length > MAX_HISTORY) {
+			const dropped = this.requestOrder.pop();
+			if (dropped) this.requests.delete(dropped);
+		}
+	}
+
+	private getFromCache(cacheKey: string): ImageRequestRecord | null {
+		const requestId = this.cache.get(cacheKey);
+		if (!requestId) return null;
+		const cached = this.requests.get(requestId);
+		if (!cached || cached.status !== 'success') return null;
+		return cached;
+	}
+
+	private createQueuedRecord(prompt: string, cacheKey: string, action: CreatorImageAction): ImageRequestRecord {
+		const now = this.now();
+		const record: ImageRequestRecord = {
+			requestId: nextRequestId(now),
+			prompt,
+			cacheKey,
+			status: 'queued',
+			action,
+			createdAt: toIso(now),
+			updatedAt: toIso(now),
+			retry: {
+				attemptCount: 0,
+				maxAttempts: this.config.maxRetries + 1,
+				reasons: []
+			},
+			result: null,
+			error: null,
+			decision: null,
+			cacheHit: false
+		};
+		this.addRecord(record);
+		return record;
+	}
+
+	private clone(record: ImageRequestRecord): ImageRequestRecord {
+		return {
+			...record,
+			retry: {
+				...record.retry,
+				reasons: [...record.retry.reasons]
+			},
+			result: record.result ? { ...record.result } : null,
+			error: record.error ? { ...record.error } : null
+		};
+	}
+
+	private async runGeneration(record: ImageRequestRecord): Promise<ImageRequestRecord> {
+		record.status = 'running';
+		this.touchRecord(record);
+
+		for (let attempt = 1; attempt <= record.retry.maxAttempts; attempt += 1) {
+			record.retry.attemptCount = attempt;
+			try {
+				const image = await this.generateImage(record.prompt);
+				record.status = 'success';
+				record.result = image;
+				record.error = null;
+				this.cache.set(record.cacheKey, record.requestId);
+				this.touchRecord(record);
+				return this.clone(record);
+			} catch (error) {
+				const reasonCode = mapReasonCode(error);
+				const retryable = isRetryable(error);
+				record.retry.reasons.push({
+					attempt,
+					reasonCode,
+					retryable,
+					message: toGuardrailSafeImageMessage(reasonCode),
+					timestamp: toIso(this.now())
+				});
+				if (!retryable || attempt >= record.retry.maxAttempts) {
+					record.status = 'failed';
+					record.error = {
+						reasonCode,
+						message: toGuardrailSafeImageMessage(reasonCode)
+					};
+					record.result = null;
+					this.touchRecord(record);
+					return this.clone(record);
+				}
+			}
+		}
+
+		record.status = 'failed';
+		record.error = {
+			reasonCode: 'unknown',
+			message: toGuardrailSafeImageMessage('unknown')
+		};
+		this.touchRecord(record);
+		return this.clone(record);
+	}
+
+	async generate(prompt: string, action: 'generate' | 'regenerate' = 'generate'): Promise<ImageRequestRecord> {
+		const normalizedPrompt = prompt.trim();
+		if (!normalizedPrompt) {
+			const now = this.now();
+			return {
+				requestId: nextRequestId(now),
+				prompt: normalizedPrompt,
+				cacheKey: '',
+				status: 'failed',
+				action,
+				createdAt: toIso(now),
+				updatedAt: toIso(now),
+				retry: { attemptCount: 0, maxAttempts: 0, reasons: [] },
+				result: null,
+				error: {
+					reasonCode: 'invalid_prompt',
+					message: toGuardrailSafeImageMessage('invalid_prompt')
+				},
+				decision: null,
+				cacheHit: false
+			};
+		}
+
+		if (!this.config.enableGrokImages) {
+			const now = this.now();
+			return {
+				requestId: nextRequestId(now),
+				prompt: normalizedPrompt,
+				cacheKey: buildImageCacheKey(normalizedPrompt, this.modelHint()),
+				status: 'failed',
+				action,
+				createdAt: toIso(now),
+				updatedAt: toIso(now),
+				retry: { attemptCount: 0, maxAttempts: 0, reasons: [] },
+				result: null,
+				error: {
+					reasonCode: 'image_disabled',
+					message: toGuardrailSafeImageMessage('image_disabled')
+				},
+				decision: 'fallback_to_static',
+				cacheHit: false
+			};
+		}
+
+		const cacheKey = buildImageCacheKey(normalizedPrompt, this.modelHint());
+		if (action === 'generate') {
+			const cached = this.getFromCache(cacheKey);
+			if (cached) {
+				const copy = this.clone(cached);
+				copy.cacheHit = true;
+				return copy;
+			}
+		}
+
+		const queued = this.createQueuedRecord(normalizedPrompt, cacheKey, action);
+		return this.runGeneration(queued);
+	}
+
+	applyDecision(requestId: string, decision: 'accepted' | 'rejected' | 'fallback_to_static'): ImageRequestRecord | null {
+		const record = this.requests.get(requestId);
+		if (!record) return null;
+		record.decision = decision;
+		this.touchRecord(record);
+		return this.clone(record);
+	}
+
+	getRequest(requestId: string): ImageRequestRecord | null {
+		const record = this.requests.get(requestId);
+		return record ? this.clone(record) : null;
+	}
+
+	summary(limit = 25): ImagePipelineSummary {
+		const ordered = this.requestOrder
+			.slice(0, limit)
+			.map((id) => this.requests.get(id))
+			.filter((record): record is ImageRequestRecord => Boolean(record));
+		const recent = ordered.map((record) => this.clone(record));
+		const successCount = [...this.requests.values()].filter((record) => record.status === 'success').length;
+		const failedCount = [...this.requests.values()].filter((record) => record.status === 'failed').length;
+		const inFlight = [...this.requests.values()].filter(
+			(record) => record.status === 'queued' || record.status === 'running'
+		).length;
+		return {
+			inFlight,
+			totalRequests: this.requests.size,
+			successCount,
+			failedCount,
+			cacheEntries: this.cache.size,
+			lastUpdatedAt: recent[0]?.updatedAt ?? null,
+			recentRequests: recent,
+			configError: this.configError
+		};
+	}
+}
+
+let singleton: ImagePipeline | null = null;
+
+export function getImagePipeline(): ImagePipeline {
+	if (!singleton) {
+		singleton = new ImagePipeline();
+	}
+	return singleton;
+}

--- a/src/routes/api/image/+server.ts
+++ b/src/routes/api/image/+server.ts
@@ -1,17 +1,77 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
-import { asRouteError, resolveImagePayload } from '$lib/server/ai/routeHelpers';
+import { asRouteError } from '$lib/server/ai/routeHelpers';
+import { getImagePipeline, type CreatorImageAction } from '$lib/server/ai/imagePipeline';
+
+interface ImagePostPayload {
+	action?: CreatorImageAction;
+	prompt?: string;
+	requestId?: string;
+}
+
+function assertPromptGuardrail(prompt: string): string | null {
+	const lower = prompt.toLowerCase();
+	if (/oswaldo/.test(lower) && /(face|bare skin|shirtless|nude|naked|skin exposed)/.test(lower)) {
+		return 'Image request blocked by safety guardrails. Adjust the prompt and try again.';
+	}
+	return null;
+}
+
+function normalizeAction(value: unknown): CreatorImageAction {
+	if (typeof value !== 'string') return 'generate';
+	if (value === 'generate' || value === 'regenerate' || value === 'accept' || value === 'reject' || value === 'fallback_to_static') {
+		return value;
+	}
+	return 'generate';
+}
+
+export const GET: RequestHandler = async () => {
+	const pipeline = getImagePipeline();
+	return json({ status: pipeline.summary() });
+};
 
 export const POST: RequestHandler = async (event) => {
 	try {
-		const payload = (await event.request.json().catch(() => ({}))) as { prompt?: string };
+		const payload = (await event.request.json().catch(() => ({}))) as ImagePostPayload;
+		const action = normalizeAction(payload.action);
+		const pipeline = getImagePipeline();
+
+		if (action === 'accept' || action === 'reject' || action === 'fallback_to_static') {
+			const requestId = typeof payload.requestId === 'string' ? payload.requestId.trim() : '';
+			if (!requestId) {
+				return json({ error: 'requestId is required for creator decision actions' }, { status: 400 });
+			}
+			const decision = action === 'accept' ? 'accepted' : action === 'reject' ? 'rejected' : 'fallback_to_static';
+			const updated = pipeline.applyDecision(requestId, decision);
+			if (!updated) {
+				return json({ error: 'Image request not found' }, { status: 404 });
+			}
+			return json({ request: updated, status: pipeline.summary() });
+		}
+
 		const prompt = typeof payload.prompt === 'string' ? payload.prompt.trim() : '';
 		if (!prompt) {
 			return json({ error: 'prompt is required' }, { status: 400 });
 		}
-		const image = await resolveImagePayload(prompt);
-		return json({ image: image ?? null });
+
+		const guardrailMessage = assertPromptGuardrail(prompt);
+		if (guardrailMessage) {
+			return json(
+				{
+					request: {
+						status: 'failed',
+						error: { reasonCode: 'guardrail', message: guardrailMessage }
+					},
+					error: guardrailMessage,
+					status: pipeline.summary()
+				},
+				{ status: 422 }
+			);
+		}
+
+		const request = await pipeline.generate(prompt, action === 'regenerate' ? 'regenerate' : 'generate');
+		const statusCode = request.status === 'failed' ? 422 : 200;
+		return json({ request, image: request.result, status: pipeline.summary() }, { status: statusCode });
 	} catch (error) {
 		return asRouteError(event, error);
 	}
 };
-

--- a/src/routes/debug/+page.svelte
+++ b/src/routes/debug/+page.svelte
@@ -1,12 +1,28 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { appendDebugError, clearDebugErrors, readDebugErrors, type DebugErrorEntry } from '$lib/debug/errorLog';
+	import type { ImagePipelineSummary } from '$lib/server/ai/imagePipeline';
 
 	let entries: DebugErrorEntry[] = [];
 	let hydrated = false;
+	let imageStatus: ImagePipelineSummary | null = null;
+	let imageStatusError = '';
 
 	function refresh(): void {
 		entries = readDebugErrors();
+	}
+
+	async function refreshImageStatus(): Promise<void> {
+		imageStatusError = '';
+		try {
+			const response = await fetch('/api/image');
+			if (!response.ok) throw new Error(`Failed to load image status (${response.status})`);
+			const body = (await response.json()) as { status?: ImagePipelineSummary };
+			imageStatus = body.status ?? null;
+		} catch (error) {
+			imageStatus = null;
+			imageStatusError = error instanceof Error ? error.message : 'Failed to load image status';
+		}
 	}
 
 	function clearAll(): void {
@@ -36,7 +52,6 @@
 		}
 		refresh();
 
-		// If storage writes are unavailable (quota/privacy mode), keep the entry visible for this session.
 		if (!entries.some((existing) => existing.id === entry.id)) {
 			entries = [entry, ...entries];
 		}
@@ -45,6 +60,7 @@
 	onMount(() => {
 		hydrated = true;
 		refresh();
+		void refreshImageStatus();
 	});
 </script>
 
@@ -56,7 +72,38 @@
 	<button class="btn btn-secondary btn-sm" on:click={refresh}>Refresh</button>
 	<button class="btn btn-secondary btn-sm" on:click={addTestEntry}>Add Test Entry</button>
 	<button class="btn btn-secondary btn-sm" on:click={clearAll}>Clear Log</button>
+	<button class="btn btn-secondary btn-sm" on:click={refreshImageStatus}>Refresh Image Status</button>
 </div>
+
+<section class="settings-section" data-testid="debug-image-status">
+	<h3>Image Pipeline Status</h3>
+	{#if imageStatusError}
+		<p class="error-banner">{imageStatusError}</p>
+	{:else if !imageStatus}
+		<p class="hint">No image pipeline data yet.</p>
+	{:else}
+		<p class="hint">
+			in-flight: {imageStatus.inFlight} · success: {imageStatus.successCount} · failed: {imageStatus.failedCount}
+			· cache: {imageStatus.cacheEntries}
+		</p>
+		{#if imageStatus.recentRequests.length > 0}
+			<ul class="debug-log-list">
+				{#each imageStatus.recentRequests.slice(0, 5) as request}
+					<li class="debug-log-item">
+						<div class="debug-log-head">
+							<span class="debug-scope">{request.action}</span>
+							<time>{new Date(request.updatedAt).toLocaleString()}</time>
+						</div>
+						<p class="debug-message">{request.status} · {request.cacheKey}</p>
+						{#if request.error}
+							<p class="debug-message">{request.error.reasonCode}: {request.error.message}</p>
+						{/if}
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	{/if}
+</section>
 
 {#if entries.length === 0}
 	<p class="hint">No debug errors recorded yet.</p>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,22 +1,59 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { gameStore } from '$lib/game';
+	import { imageCreatorStore } from '$lib/client/imageCreatorState';
 	import type { GameSettings } from '$lib/contracts';
+	import type { ImageRequestRecord, ImagePipelineSummary } from '$lib/server/ai/imagePipeline';
 
 	let settings: GameSettings | null = null;
+	let creatorPrompt = '';
+	let imageRequest: ImageRequestRecord | null = null;
+	let imageStatus: ImagePipelineSummary | null = null;
+	let imageError = '';
+	let imageWorking = false;
 
 	const unsubscribe = gameStore.subscribe((state) => {
 		settings = state.settings;
 	});
 
+	const unsubscribeImage = imageCreatorStore.subscribe((state) => {
+		creatorPrompt = state.prompt;
+		imageRequest = state.activeRequest;
+		imageStatus = state.status;
+		imageError = state.error;
+		imageWorking = state.isWorking;
+	});
+
 	onMount(() => {
 		gameStore.initialize();
-		return () => unsubscribe();
+		void imageCreatorStore.refreshStatus();
+		return () => {
+			unsubscribe();
+			unsubscribeImage();
+		};
 	});
 
 	function updateShowLessons(value: boolean): void {
 		if (!settings) return;
 		gameStore.updateSettings({ showLessons: value });
+	}
+
+	function updatePrompt(event: Event): void {
+		const value = (event.currentTarget as HTMLTextAreaElement).value;
+		imageCreatorStore.setPrompt(value);
+	}
+
+	async function generateImage(): Promise<void> {
+		await imageCreatorStore.triggerAction('generate', { prompt: creatorPrompt });
+	}
+
+	async function regenerateImage(): Promise<void> {
+		await imageCreatorStore.triggerAction('regenerate', { prompt: creatorPrompt });
+	}
+
+	async function applyDecision(action: 'accept' | 'reject' | 'fallback_to_static'): Promise<void> {
+		if (!imageRequest?.requestId) return;
+		await imageCreatorStore.triggerAction(action, { requestId: imageRequest.requestId });
 	}
 </script>
 
@@ -46,5 +83,59 @@
 				Off
 			</button>
 		</div>
+	</section>
+
+	<section class="settings-section" data-testid="creator-image-panel">
+		<h3>Creator Image Pipeline</h3>
+		<p class="hint">Generate, review, and decide whether to ship dynamic images for demo scenes.</p>
+
+		<label for="creator-image-prompt">Scene image prompt</label>
+		<textarea
+			id="creator-image-prompt"
+			class="input"
+			rows="3"
+			value={creatorPrompt}
+			on:input={updatePrompt}
+			placeholder="Describe an image-safe scene composition..."
+		></textarea>
+
+		<div class="toggle-row">
+			<button class="btn btn-primary" on:click={generateImage} disabled={imageWorking}>Generate</button>
+			<button class="btn btn-secondary" on:click={regenerateImage} disabled={imageWorking}>Regenerate</button>
+		</div>
+
+		{#if imageError}
+			<p class="error-banner">{imageError}</p>
+		{/if}
+
+		{#if imageRequest}
+			<div class="creator-request-card" data-testid="creator-image-status">
+				<p><strong>Status:</strong> {imageRequest.status}</p>
+				<p><strong>Cache key:</strong> <code>{imageRequest.cacheKey || 'n/a'}</code></p>
+				<p><strong>Retries:</strong> {imageRequest.retry.attemptCount}/{imageRequest.retry.maxAttempts}</p>
+				{#if imageRequest.error}
+					<p><strong>Last error:</strong> {imageRequest.error.reasonCode} — {imageRequest.error.message}</p>
+				{/if}
+				{#if imageRequest.cacheHit}
+					<p class="hint">Cache reused for this prompt.</p>
+				{/if}
+				<div class="toggle-row">
+					<button class="btn btn-primary" on:click={() => applyDecision('accept')} disabled={imageWorking}>Accept</button>
+					<button class="btn btn-secondary" on:click={() => applyDecision('reject')} disabled={imageWorking}>Reject</button>
+					<button class="btn btn-secondary" on:click={() => applyDecision('fallback_to_static')} disabled={imageWorking}>
+						Fallback to Static
+					</button>
+				</div>
+			</div>
+		{/if}
+
+		{#if imageStatus}
+			<div class="creator-pipeline-summary" data-testid="creator-image-summary">
+				<p>
+					<strong>Pipeline:</strong> {imageStatus.inFlight} in-flight / {imageStatus.successCount} success /
+					{imageStatus.failedCount} failed / cache {imageStatus.cacheEntries}
+				</p>
+			</div>
+		{/if}
 	</section>
 {/if}

--- a/tests/unit/imagePipeline.spec.ts
+++ b/tests/unit/imagePipeline.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+import { ImagePipeline } from '../../src/lib/server/ai/imagePipeline';
+import { AiProviderError } from '../../src/lib/server/ai/provider.interface';
+
+const baseConfig = {
+	provider: 'grok' as const,
+	enableGrokText: true,
+	enableGrokImages: true,
+	enableProviderProbe: false,
+	aiAuthBypass: false,
+	outageMode: 'hard_fail' as const,
+	xaiApiKey: 'test',
+	grokTextModel: 'text-model',
+	grokImageModel: 'image-model',
+	maxOutputTokens: 1000,
+	requestTimeoutMs: 5000,
+	maxRetries: 2,
+	retryBackoffMs: [1, 1]
+};
+
+test('reuses cache for same prompt on generate action', async () => {
+	let calls = 0;
+	const pipeline = new ImagePipeline({
+		config: baseConfig,
+		generateImage: async () => {
+			calls += 1;
+			return { url: `https://example.com/${calls}.png` };
+		}
+	});
+
+	const first = await pipeline.generate('Sydney at motel window', 'generate');
+	expect(first.status).toBe('success');
+	expect(first.cacheHit).toBeFalsy();
+
+	const second = await pipeline.generate('Sydney at motel window', 'generate');
+	expect(second.status).toBe('success');
+	expect(second.cacheHit).toBeTruthy();
+	expect(second.result?.url).toBe(first.result?.url);
+	expect(calls).toBe(1);
+});
+
+test('bounded retries capture reason codes and eventually succeed', async () => {
+	let calls = 0;
+	const pipeline = new ImagePipeline({
+		config: { ...baseConfig, maxRetries: 2 },
+		generateImage: async () => {
+			calls += 1;
+			if (calls < 3) {
+				throw new AiProviderError('rate limited', {
+					code: 'rate_limit',
+					retryable: true,
+					status: 429
+				});
+			}
+			return { b64: 'abc123' };
+		}
+	});
+
+	const result = await pipeline.generate('Late night convenience store', 'generate');
+	expect(result.status).toBe('success');
+	expect(result.retry.attemptCount).toBe(3);
+	expect(result.retry.reasons).toHaveLength(2);
+	expect(result.retry.reasons[0].reasonCode).toBe('rate_limit');
+	expect(result.retry.reasons[1].reasonCode).toBe('rate_limit');
+});
+
+test('creator decisions update request records', async () => {
+	const pipeline = new ImagePipeline({
+		config: baseConfig,
+		generateImage: async () => ({ url: 'https://example.com/success.png' })
+	});
+
+	const request = await pipeline.generate('Sydney checking phones in dim motel room', 'generate');
+	const decided = pipeline.applyDecision(request.requestId, 'accepted');
+	expect(decided?.decision).toBe('accepted');
+
+	const fallback = pipeline.applyDecision(request.requestId, 'fallback_to_static');
+	expect(fallback?.decision).toBe('fallback_to_static');
+});


### PR DESCRIPTION
### Motivation
- Provide explicit, observable lifecycle state for image generation so operators can see queued/running/success/failed status during demos and debugging.
- Centralize bounded retry logic and reason-code capture at the pipeline layer to avoid nested provider retries and surface guardrail-safe messages to creators.
- Expose pipeline telemetry (status, cache, recent requests) and creator actions so images can be regenerated/accepted/rejected or fallen back to static assets during demo prep.

### Description
- Introduced a server-side ImagePipeline manager that tracks request records, bounded retry attempts with reason codes, cache-key generation/reuse, creator decisions, and guardrail-safe user messages (`src/lib/server/ai/imagePipeline.ts`).
- Extended `/api/image` to support `GET` status snapshots and action-based `POST` semantics (`generate`/`regenerate`/`accept`/`reject`/`fallback_to_static`) with pre-provider guardrail rejection (`src/routes/api/image/+server.ts`).
- Simplified the Grok image adapter to perform a single provider call per invocation so retries are orchestrated by the pipeline layer (`src/lib/server/ai/providers/grok.ts`).
- Added a client-side creator store and Settings UI panel for creator workflows, plus Debug and Demo Readiness instrumentation to surface pipeline state (`src/lib/client/imageCreatorState.ts`, `src/routes/settings/+page.svelte`, `src/routes/debug/+page.svelte`, `src/routes/api/demo/readiness/+server.ts`).
- Updated docs and lessons to reflect operational changes and usage: `README.md`, `CHANGELOG.md`, and `AI_LESSONS_LEARNED.md`.

### Testing
- Ran lint and marker checks with `npm run lint` and `npm test`, both succeeded.
- Type/TS validation passed with `npm run check` (svelte-check) after narrowing node imports for portability.
- Unit tests for the pipeline passed via Playwright unit runner: `npx playwright test -c playwright-unit.config.js tests/unit/imagePipeline.spec.ts` (all tests passed).
- Focused E2E API assertions for the image pipeline passed: `npx playwright test tests/e2e/demo-reliability.spec.js -g "image pipeline status + creator actions"` succeeded, and overall request-level API checks in `npm run test:e2e` passed; full browser-page E2E failed in this environment due to missing Playwright browser binary/Chromium launch issues (environment blocked), see notes for reproduction (`npx playwright install` then re-run `npm run test:e2e`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992f1f8a54c8320b67b156f32c91af8)

## Summary by Sourcery

Introduce a centralized image generation pipeline with explicit lifecycle tracking, retries, caching, and creator controls, and surface its state via API, UI, and demo readiness tooling.

New Features:
- Add an image pipeline manager that tracks request records, lifecycle status, bounded retries, cache keys, and creator decisions for image generation.
- Expose image pipeline status and creator actions over the `/api/image` endpoint, including guardrail-aware error responses and decision updates.
- Add a client-side creator image store and settings panel to drive prompt entry, generation/regeneration, and accept/reject/fallback workflows.
- Surface image pipeline status and recent activity in the debug page and demo readiness API for operator visibility during demos.

Enhancements:
- Simplify the Grok image provider to a single-call implementation and delegate retry behavior to the centralized pipeline layer.

Documentation:
- Document the new image pipeline lifecycle, visibility, and creator workflow changes in the README, changelog, and AI lessons learned.

Tests:
- Add unit tests for the image pipeline’s caching, retry behavior, and creator decisions, and extend demo reliability E2E tests to cover image pipeline status and creator actions.