### PR TITLE
🔒 Secure readiness endpoint by sanitizing config details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased] - 2026-02-22
+
+### Security
+
+- **Hardening:** Sanitized `/api/demo/readiness` output to prevent leakage of internal configuration details (e.g., specific provider usage, auth bypass status).
+
+
 ## [Unreleased] - 2026-02-07
 
 ### Changed

--- a/tests/e2e/demo-reliability.spec.js
+++ b/tests/e2e/demo-reliability.spec.js
@@ -62,17 +62,17 @@ test.describe('SvelteKit route + playthrough reliability', () => {
 
 		expect(checkIds).toEqual(
 			expect.arrayContaining([
-				'provider_grok',
-				'text_enabled',
-				'api_key_present',
-				'outage_hard_fail',
-				'auth_bypass_disabled',
-				'image_mode_static_default',
-				'provider_probe'
+				'ai_provider',
+				'text_generation',
+				'api_key_status',
+				'outage_policy',
+				'security_mode',
+				'image_generation',
+				'connectivity_probe'
 			])
 		);
 
-		const apiKeyCheck = body.checks.find((check) => check.id === 'api_key_present');
+		const apiKeyCheck = body.checks.find((check) => check.id === 'api_key_status');
 		expect(Boolean(apiKeyCheck)).toBeTruthy();
 		if (HAS_XAI_KEY) {
 			expect(apiKeyCheck.ok).toBeTruthy();


### PR DESCRIPTION
Sanitized the `/api/demo/readiness` endpoint to prevent leaking internal configuration details such as provider names, environment variable keys, and auth bypass status. Refactored the checks to use generic IDs (`ai_provider`, `text_generation`, etc.) and generic labels. Updated e2e tests to verify the generic payload structure. Updated CHANGELOG.md with a security note.

---
*PR created automatically by Jules for task [11014136399107715270](https://jules.google.com/task/11014136399107715270) started by @Phazzie*

## Summary by Sourcery

Harden the demo readiness endpoint by returning generic, non-sensitive configuration and status information while preserving readiness scoring and behavior.

Bug Fixes:
- Prevent the readiness endpoint from exposing sensitive internal configuration details such as specific provider usage, environment flags, and auth bypass status.

Enhancements:
- Standardize readiness check identifiers and labels to generic AI-related concepts and human-readable details, including for connectivity probing.
- Update readiness summary messaging to reference a generic AI demo mode rather than a specific provider.

Documentation:
- Document the readiness endpoint security hardening in the changelog under an unreleased security section.

Tests:
- Adjust demo reliability end-to-end tests to assert the new generic readiness check identifiers and API key check semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Hardened the readiness check endpoint to sanitize output and prevent leakage of sensitive internal configuration details, including provider configuration and security settings.

* **Tests**
  * Updated readiness validation tests to align with security improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->