### PR TITLE
fix: rescue review findings from March 21 branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "test": "node tests/noLegacyProviderMarkers.js && node tests/storyEngineRuntimeSelection.js",
-    "lint": "eslint \"tests/e2e/**/*.js\" tests/noLegacyProviderMarkers.js --max-warnings=0",
-    "lint:fix": "eslint \"tests/e2e/**/*.js\" tests/noLegacyProviderMarkers.js --fix",
+    "lint": "eslint \"tests/e2e/**/*.js\" tests/noLegacyProviderMarkers.js tests/storyEngineRuntimeSelection.js \"tests/narrative/**/*.js\" --max-warnings=0",
+    "lint:fix": "eslint \"tests/e2e/**/*.js\" tests/noLegacyProviderMarkers.js tests/storyEngineRuntimeSelection.js \"tests/narrative/**/*.js\" --fix",
     "format": "prettier --write \"js/**/*.js\" \"src/**/*.{ts,svelte,css}\" \"*.css\" \"*.html\"",
     "serve": "vite preview --host 0.0.0.0 --port 8080",
     "dev": "vite dev",

--- a/src/lib/contracts/game.ts
+++ b/src/lib/contracts/game.ts
@@ -188,8 +188,8 @@ export function mergeThreadUpdates(
 
 	for (const key of Object.keys(updates) as Array<keyof StoryThreads>) {
 		if (key === 'boundariesSet') {
-			if (Array.isArray(updates.boundariesSet) && updates.boundariesSet.length > 0) {
-				merged.boundariesSet = [...merged.boundariesSet, ...updates.boundariesSet];
+			if (Array.isArray(updates.boundariesSet)) {
+				merged.boundariesSet = [...updates.boundariesSet];
 			}
 			continue;
 		}

--- a/src/routes/debug/+page.svelte
+++ b/src/routes/debug/+page.svelte
@@ -76,7 +76,7 @@
 					<li class="debug-log-item">
 						<div class="debug-log-head">
 							<span class="debug-scope">{entry.scope}</span>
-							<time>{new Date(entry.timestamp).toLocaleString()}</time>
+							<time>{hydrated ? new Date(entry.timestamp).toLocaleString() : entry.timestamp}</time>
 						</div>
 						<p class="debug-message">{entry.message}</p>
 						{#if entry.details}


### PR DESCRIPTION
## Summary
- rescue the unmerged review-fix commit from `claude/review-codex-handoff-2dvED`
- include the missing lint targets for `tests/storyEngineRuntimeSelection.js` and `tests/narrative/**/*.js`
- fix `mergeThreadUpdates` so `boundariesSet` is replaced instead of duplicated
- guard the debug timestamp locale formatting behind hydration to avoid SSR/client mismatch risk

## Source
- cherry-picked from `328e10fdb9cb6d53314802b527a7462668b84a31`

## Validation
- `npm run lint`
- `npm test`
- `npm run check`

## Summary by Sourcery

Update test linting configuration and adjust thread merging and debug timestamp handling.

Bug Fixes:
- Ensure mergeThreadUpdates replaces boundariesSet with the updated set instead of appending to the existing one.
- Prevent server/client mismatch by only locale-formatting debug timestamps after hydration.

Build:
- Extend lint scripts to cover storyEngineRuntimeSelection and narrative test files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test linting configuration to include additional test files.

* **Bug Fixes**
  * Fixed boundary update merging logic to properly overwrite existing values.
  * Fixed debug log timestamp rendering on initial page load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->