### PR TITLE
Add auth login/logout routes for signed nv_session and smoke tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added / Changed
 
+- **Builder Session Auth Routes + Smoke Coverage (2026-04-25):** Added `POST /api/auth/login` and `POST /api/auth/logout` SvelteKit routes that issue/clear signed `nv_session` cookies via `createSignedSessionCookieValue`, with explicit cookie attributes (`httpOnly`, `secure`, `sameSite`, `path`, `maxAge`). Expanded runtime smoke coverage to prove `/builder` transitions from anonymous `401` to authorized `200` with a valid builder-role session and returns to `401` after logout. Updated `README.md` with operator login/logout steps for local runs.
 - **CI & Test Coverage Remediation (2026-04-13):**
   - **Phase 1 — Playwright config fix:** Deleted legacy `playwright-unit.config.js` (4 workers, 10s timeout). CI now uses `npm run test:unit` which canonically points to `playwright.unit.config.ts` (2 workers, 15s timeout). One config, no divergence.
   - **Phase 2 — ESLint covers `src/`:** Added `@typescript-eslint/parser`, `@typescript-eslint/eslint-plugin`, and `eslint-plugin-svelte` to devDependencies. `eslint.config.js` now lints all `.ts` and `.svelte` files under `src/`. Fixed two source violations: renamed unused `event` param to `_event` in `readiness/+server.ts`, and extracted inline `import()` type annotations to top-level `import type` in `next/+server.ts`. Configured `eqeqeq` rule with `{ null: 'ignore' }` to preserve the intentional `value == null` idiom. `npm run lint` exits 0 and covers source.

--- a/README.md
+++ b/README.md
@@ -90,9 +90,29 @@ To add a new story cartridge:
 Builder surfaces:
 
 - Route: `/builder`
+- Operator auth APIs: `POST /api/auth/login`, `POST /api/auth/logout`
 - Draft generation API: `/api/builder/generate-draft`
 - Prose evaluation API: `/api/builder/evaluate-prose`
 - Builder implementation: `src/routes/builder/+page.svelte`, `src/lib/server/ai/builder.ts`, `src/lib/builder/store.ts`
+
+Operator login steps (local/dev):
+
+1. Start the app (`npm run dev`) with `AUTH_SESSION_SECRET` set.
+2. Log in as a builder-capable role (`author` or `editor`):
+
+```bash
+curl -i -X POST http://127.0.0.1:5173/api/auth/login \
+  -H 'content-type: application/json' \
+  -d '{"userId":"operator-demo","role":"author"}'
+```
+
+3. Copy the returned `Set-Cookie: nv_session=...` header value and send it as `Cookie` when calling `/builder` or `/api/builder/*`.
+4. Clear the session when done:
+
+```bash
+curl -i -X POST http://127.0.0.1:5173/api/auth/logout \
+  -H 'Cookie: nv_session=<paste-cookie-value>'
+```
 
 ## Build + Preview
 

--- a/README.md
+++ b/README.md
@@ -97,21 +97,28 @@ Builder surfaces:
 
 Operator login steps (local/dev):
 
-1. Start the app (`npm run dev`) with `AUTH_SESSION_SECRET` set.
-2. Log in as a builder-capable role (`author` or `editor`):
+1. Start the app (`npm run dev`) with `AUTH_SESSION_SECRET` and `DEMO_AUTH_ENABLED=1` set.
+2. Log in as a builder-capable role (`author` or `editor`), storing cookies in a jar:
 
 ```bash
-curl -i -X POST http://127.0.0.1:5173/api/auth/login \
+curl -X POST http://127.0.0.1:5173/api/auth/login \
   -H 'content-type: application/json' \
-  -d '{"userId":"operator-demo","role":"author"}'
+  -d '{"userId":"operator-demo","role":"author"}' \
+  -c /tmp/nv.cookies
 ```
 
-3. Copy the returned `Set-Cookie: nv_session=...` header value and send it as `Cookie` when calling `/builder` or `/api/builder/*`.
+3. Call `/builder` or `/api/builder/*` endpoints with the stored session:
+
+```bash
+curl http://127.0.0.1:5173/builder \
+  -b /tmp/nv.cookies
+```
+
 4. Clear the session when done:
 
 ```bash
-curl -i -X POST http://127.0.0.1:5173/api/auth/logout \
-  -H 'Cookie: nv_session=<paste-cookie-value>'
+curl -X POST http://127.0.0.1:5173/api/auth/logout \
+  -b /tmp/nv.cookies
 ```
 
 ## Build + Preview

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -2,7 +2,7 @@ import { json, type RequestEvent } from '@sveltejs/kit';
 
 export const BUILDER_ROLES = ['author', 'editor'] as const;
 export const SESSION_COOKIE_NAME = 'nv_session';
-const SESSION_MAX_AGE_SECONDS = 60 * 60 * 12;
+export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 12;
 
 const encoder = new TextEncoder();
 // Keep this small and bounded: normal runtime uses one active secret, but rotation overlap

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -1,4 +1,5 @@
 import { json, type RequestEvent } from '@sveltejs/kit';
+import { dev } from '$app/environment';
 
 export const BUILDER_ROLES = ['author', 'editor'] as const;
 export const SESSION_COOKIE_NAME = 'nv_session';
@@ -169,4 +170,14 @@ export function getAuthSessionSecret(): string | undefined {
 
 export async function getSessionUser(event: RequestEvent): Promise<SessionUser | null> {
 	return parseSessionCookie(event.cookies.get(SESSION_COOKIE_NAME), getAuthSessionSecret());
+}
+
+export function useSecureCookies(url: URL): boolean {
+	if (url.protocol === 'https:') return true;
+	return !dev;
+}
+
+export function isDemoAuthEnabled(): boolean {
+	const runtimeProcess = globalThis as { process?: { env?: Record<string, string | undefined> } };
+	return runtimeProcess.process?.env?.DEMO_AUTH_ENABLED === '1';
 }

--- a/src/routes/api/auth/login/+server.ts
+++ b/src/routes/api/auth/login/+server.ts
@@ -1,0 +1,60 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+
+import {
+	BUILDER_ROLES,
+	SESSION_COOKIE_NAME,
+	SESSION_MAX_AGE_SECONDS,
+	createSignedSessionCookieValue,
+	isBuilderRole,
+	getAuthSessionSecret
+} from '$lib/server/auth';
+
+function useSecureCookies(url: URL): boolean {
+	if (url.protocol === 'https:') return true;
+	return (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env?.NODE_ENV === 'production';
+}
+
+export const POST: RequestHandler = async ({ request, cookies, url }) => {
+	const payload = (await request.json().catch(() => ({}))) as {
+		userId?: string;
+		role?: string;
+	};
+
+	const userId = typeof payload.userId === 'string' ? payload.userId.trim() : '';
+	const role = typeof payload.role === 'string' ? payload.role.trim() : '';
+
+	if (!userId) {
+		return json({ error: { code: 'invalid_user', message: 'userId is required.' } }, { status: 400 });
+	}
+
+	if (!isBuilderRole(role)) {
+		return json(
+			{
+				error: {
+					code: 'invalid_role',
+					message: `role must be one of: ${BUILDER_ROLES.join(', ')}.`
+				}
+			},
+			{ status: 400 }
+		);
+	}
+
+	const secret = getAuthSessionSecret();
+	if (!secret) {
+		return json(
+			{ error: { code: 'auth_not_configured', message: 'AUTH_SESSION_SECRET is not configured.' } },
+			{ status: 503 }
+		);
+	}
+
+	const value = await createSignedSessionCookieValue({ userId, role }, secret);
+	cookies.set(SESSION_COOKIE_NAME, value, {
+		httpOnly: true,
+		secure: useSecureCookies(url),
+		sameSite: 'lax',
+		path: '/',
+		maxAge: SESSION_MAX_AGE_SECONDS
+	});
+
+	return json({ ok: true, user: { userId, role } });
+};

--- a/src/routes/api/auth/login/+server.ts
+++ b/src/routes/api/auth/login/+server.ts
@@ -6,15 +6,24 @@ import {
 	SESSION_MAX_AGE_SECONDS,
 	createSignedSessionCookieValue,
 	isBuilderRole,
-	getAuthSessionSecret
+	getAuthSessionSecret,
+	useSecureCookies,
+	isDemoAuthEnabled
 } from '$lib/server/auth';
 
-function useSecureCookies(url: URL): boolean {
-	if (url.protocol === 'https:') return true;
-	return (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env?.NODE_ENV === 'production';
-}
-
 export const POST: RequestHandler = async ({ request, cookies, url }) => {
+	if (!isDemoAuthEnabled()) {
+		return json(
+			{
+				error: {
+					code: 'demo_auth_disabled',
+					message: 'Demo authentication is not enabled. Set DEMO_AUTH_ENABLED=1 to use this endpoint.'
+				}
+			},
+			{ status: 403 }
+		);
+	}
+
 	const payload = (await request.json().catch(() => ({}))) as {
 		userId?: string;
 		role?: string;

--- a/src/routes/api/auth/logout/+server.ts
+++ b/src/routes/api/auth/logout/+server.ts
@@ -1,0 +1,20 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+
+import { SESSION_COOKIE_NAME } from '$lib/server/auth';
+
+function useSecureCookies(url: URL): boolean {
+	if (url.protocol === 'https:') return true;
+	return (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env?.NODE_ENV === 'production';
+}
+
+export const POST: RequestHandler = async ({ cookies, url }) => {
+	cookies.set(SESSION_COOKIE_NAME, '', {
+		httpOnly: true,
+		secure: useSecureCookies(url),
+		sameSite: 'lax',
+		path: '/',
+		maxAge: 0
+	});
+
+	return json({ ok: true });
+};

--- a/src/routes/api/auth/logout/+server.ts
+++ b/src/routes/api/auth/logout/+server.ts
@@ -1,11 +1,6 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 
-import { SESSION_COOKIE_NAME } from '$lib/server/auth';
-
-function useSecureCookies(url: URL): boolean {
-	if (url.protocol === 'https:') return true;
-	return (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env?.NODE_ENV === 'production';
-}
+import { SESSION_COOKIE_NAME, useSecureCookies } from '$lib/server/auth';
 
 export const POST: RequestHandler = async ({ cookies, url }) => {
 	cookies.set(SESSION_COOKIE_NAME, '', {

--- a/tests/storyEngineRuntimeSelection.js
+++ b/tests/storyEngineRuntimeSelection.js
@@ -24,6 +24,14 @@ function formatCapturedOutput(stdout, stderr) {
 	return sections.length ? `\n${sections.join('\n\n')}` : '';
 }
 
+function extractCookiePair(setCookieHeader) {
+	const firstSegment = String(setCookieHeader || '')
+		.split(';')
+		.map((segment) => segment.trim())
+		.find(Boolean);
+	return firstSegment || '';
+}
+
 /**
  * Resolve the npm executable to use for spawning child processes.
  * When invoked via `npm test`, npm sets npm_execpath to the actual npm script
@@ -208,6 +216,58 @@ async function runScenario({
 		if (expectStoryId === 'starter-kit') {
 			assert.doesNotMatch(homeHtml, /No Vacancies/i, `${label}: should not leak No Vacancies shell copy`);
 		}
+
+		const anonymousBuilder = await fetch(`http://${HOST}:${port}/builder`);
+		assert.equal(anonymousBuilder.status, 401, `${label}: anonymous /builder should be 401`);
+
+		const invalidRoleLogin = await fetch(`http://${HOST}:${port}/api/auth/login`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ userId: 'story-smoke-viewer', role: 'viewer' })
+		});
+		assert.equal(invalidRoleLogin.status, 400, `${label}: invalid role login should fail`);
+
+		const validLogin = await fetch(`http://${HOST}:${port}/api/auth/login`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ userId: 'story-smoke-author', role: 'author' })
+		});
+		assert.equal(validLogin.status, 200, `${label}: valid login should succeed`);
+		const loginSetCookie = validLogin.headers.get('set-cookie');
+		assert.match(
+			String(loginSetCookie || ''),
+			/HttpOnly/i,
+			`${label}: login must issue HttpOnly session cookie`
+		);
+		assert.match(String(loginSetCookie || ''), /SameSite=Lax/i, `${label}: login must set SameSite=Lax`);
+		assert.match(String(loginSetCookie || ''), /Path=\//i, `${label}: login must set Path=/`);
+		assert.match(String(loginSetCookie || ''), /Max-Age=43200/i, `${label}: login must set 12h max-age`);
+		const authCookie = extractCookiePair(loginSetCookie);
+		assert.match(authCookie, /^nv_session=/, `${label}: login should return nv_session cookie`);
+
+		const authorizedBuilder = await fetch(`http://${HOST}:${port}/builder`, {
+			headers: {
+				cookie: authCookie
+			}
+		});
+		assert.equal(authorizedBuilder.status, 200, `${label}: signed-in author should access /builder`);
+
+		const logoutResponse = await fetch(`http://${HOST}:${port}/api/auth/logout`, {
+			method: 'POST',
+			headers: {
+				cookie: authCookie
+			}
+		});
+		assert.equal(logoutResponse.status, 200, `${label}: logout should succeed`);
+		const logoutSetCookie = logoutResponse.headers.get('set-cookie');
+		assert.match(String(logoutSetCookie || ''), /Max-Age=0/i, `${label}: logout should clear cookie`);
+
+		const clearedBuilder = await fetch(`http://${HOST}:${port}/builder`, {
+			headers: {
+				cookie: extractCookiePair(logoutSetCookie)
+			}
+		});
+		assert.equal(clearedBuilder.status, 401, `${label}: cleared session should return /builder to 401`);
 
 		const sessionCookie = await createSignedSessionCookieValue({
 			userId: 'story-smoke-author',


### PR DESCRIPTION
### Motivation
- Provide a simple operator/demo auth flow so `/builder` can be exercised in local/preview runs with a signed session cookie instead of relying on external identity plumbing. 
- Ensure cookie TTL and signed payload expiry are aligned and cookie attributes are explicit for security/clarity. 
- Make the operator flow discoverable by documenting login/logout steps in `README.md`. 
- Risk: the login endpoint currently accepts caller-provided `userId` (role is limited to builder roles), so this should be paired with upstream identity controls for production use.

### Description
- Added `POST /api/auth/login` (`src/routes/api/auth/login/+server.ts`) which validates `userId` and requires `role` to be one of `BUILDER_ROLES`, signs a session using `createSignedSessionCookieValue`, and sets the `nv_session` cookie with explicit attributes `httpOnly`, `secure`, `sameSite: 'lax'`, `path: '/'`, and `maxAge` using the exported `SESSION_MAX_AGE_SECONDS`.
- Added `POST /api/auth/logout` (`src/routes/api/auth/logout/+server.ts`) which clears `nv_session` by setting it with `maxAge: 0` and the same explicit attributes.
- Exported `SESSION_MAX_AGE_SECONDS` from `src/lib/server/auth.ts` so cookie TTL matches the signed session envelope expiry.
- Expanded runtime smoke integration in `tests/storyEngineRuntimeSelection.js` to assert `/builder` transitions from anonymous `401` to authorized `200` after a valid login (and back to `401` after logout), to verify `Set-Cookie` attributes, and to reject invalid-role login attempts.
- Documented operator login/logout steps in `README.md` and recorded the change in `CHANGELOG.md`.

### Testing
- Ran `npm run lint` and it completed successfully. 
- Ran `npm test` (runtime story-selection smoke scenarios) and all scenarios passed; the smoke checks verified anonymous `/builder` returns `401`, invalid role login returns `400`, valid login issues an `nv_session` cookie and `/builder` returns `200`, and logout clears the cookie and `/builder` returns `401` again. 
- Commands executed: `npm run lint` and `npm test` (both succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec150cf0348320a584f0a5ba07feb1)

## Summary by Sourcery

Add authenticated session login/logout endpoints for builder users and wire them into local operator flow, aligning cookie configuration with session expiry and verifying access control via tests.

New Features:
- Introduce POST /api/auth/login endpoint to issue signed nv_session cookies for authorized builder roles.
- Introduce POST /api/auth/logout endpoint to clear the nv_session cookie and end the session.

Enhancements:
- Export SESSION_MAX_AGE_SECONDS so cookie lifetime matches the signed session envelope TTL.
- Document local operator login/logout flow for the builder UI in the README.
- Record the new builder session auth routes and coverage in the changelog.

Tests:
- Extend runtime smoke tests to cover login/logout, cookie attributes, and /builder access transitions between anonymous, authenticated, and logged-out states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure login and logout endpoints using signed session cookies; builder access now requires an authenticated session

* **Documentation**
  * Updated operator guides with step-by-step auth setup and usage

* **Tests**
  * Expanded smoke and unit test coverage for auth/session lifecycle and stabilized CI/test configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->