### PR TITLE
Sprint 3-fix + Sprint 4 + Sprint 5: prompt wiring, model config, lessons catalog

### DIFF
--- a/src/lib/narrative/lessonsCatalog.ts
+++ b/src/lib/narrative/lessonsCatalog.ts
@@ -41,7 +41,7 @@ export const lessons: Lesson[] = [
         insight:
             "It's not the lack of applause that hurts. It's that they genuinely don't see the load.",
         emotionalStakes: [
-            'Feeling invisible in your own contribution',
+            'The work that disappears into the result, noticed only when absent',
             "The gap between what you know you're doing and what they perceive",
             'Being gaslit by incomprehension'
         ],
@@ -77,7 +77,7 @@ export const lessons: Lesson[] = [
         insight:
             'Your attention, energy, explanation, and patience ARE the dynamic. Without you supplying them, it dies.',
         emotionalStakes: [
-            "Realizing you're the entire engine",
+            "You are the engine. The machine does not know the difference between you and the fuel.",
             "The terrifying question: 'What happens if I stop?'",
             'The exhaustion of being the only source'
         ],
@@ -96,7 +96,7 @@ export const lessons: Lesson[] = [
         insight: 'Are you valued because of what you produce, or because you exist?',
         emotionalStakes: [
             'The fear of being replaceable if you stop producing',
-            'Wondering if anyone would miss YOU vs. miss your function',
+            'The gap between missing a person and missing a utility service',
             'The exhaustion of earning your place daily'
         ],
         storyTriggers: [
@@ -198,7 +198,7 @@ export const lessons: Lesson[] = [
         id: 11,
         title: 'See It AND Act Accordingly',
         quote: "It's more than that. I think we want people to see that and act accordingly. Like... if you know I'm breaking my back to make this money, don't loan your buddy $50 so he can buy drugs the day before rent is due.",
-        insight: "It's not enough to acknowledge the work. You have to change your behavior.",
+        insight: "Words about what they see do not change who does the work.",
         emotionalStakes: [
             'The gap between words and actions',
             'Recognition without change is just manipulation',
@@ -251,10 +251,10 @@ export const lessons: Lesson[] = [
         id: 14,
         title: 'The System Only Responds to Load Distribution',
         quote: "The system doesn't care about explanations. It only responds to load distribution.",
-        insight: "Explanations don't matter. Only who carries what.",
+        insight: "Load distribution is the only language the system speaks. Everything else is noise.",
         emotionalStakes: [
             'The futility of communication',
-            'Realizing talk is cheap',
+            'Words as currency that inflates and loses value each time they aren\'t backed by action',
             'The clarity of just looking at who does what'
         ],
         storyTriggers: [
@@ -269,7 +269,7 @@ export const lessons: Lesson[] = [
         title: 'Infrastructure Gets Blamed',
         quote: "When infrastructure works, it's invisible. When it fails, everyone notices.",
         insight:
-            "When you're infrastructure, you're blamed for failures but not credited for prevention.",
+            "Blamed when one thing breaks. Invisible when ninety-nine things hold.",
         emotionalStakes: [
             'The unfairness of being blamed for the one thing that broke',
             "No credit for the 100 things that didn't break",
@@ -310,7 +310,7 @@ export const lessons: Lesson[] = [
             "If my presence doesn't change how you act, plan, or sacrifice, then what am I to you?",
         emotionalStakes: [
             'The devastating clarity of this question',
-            'Realizing you might not like the answer',
+            'The trap of the question you already know the answer to',
             'The beginning of real change or real leaving'
         ],
         storyTriggers: [
@@ -319,6 +319,177 @@ export const lessons: Lesson[] = [
             "She can't unsee it now"
         ],
         unconventionalAngle: "The question you're afraid to ask because you already know the answer"
+    }
+
+    {
+        id: 18,
+        title: 'The Emotional Accountant',
+        quote: "You track every favor, every loan, every 'you'll pay me back.' They don't know there's a ledger.",
+        insight: "The ledger exists. Only one of you is keeping it.",
+        emotionalStakes: [
+            'The weight of tracking what no one else bothers to track',
+            'The exhaustion of being the only one who remembers',
+            'The moment you stop keeping score and everything tips over'
+        ],
+        storyTriggers: [
+            "Sydney runs the numbers in her head: $40 owed, $65 due, $12 in the account",
+            "Trina says 'you know I'm good for it' for the fourth time this week",
+            "Sydney stops counting and the math gets worse"
+        ],
+        unconventionalAngle: "Your memory is not a virtue. It's a burden you chose to carry for people who chose not to."
+    },
+    {
+        id: 19,
+        title: 'The Cover Story',
+        quote: "When you make someone sound better than they are, you're not protecting them. You're doing unpaid PR.",
+        insight: "Every excuse you make for them is a sentence you wrote for their reputation and signed with your credibility.",
+        emotionalStakes: [
+            'The slow erosion of your own credibility through borrowed goodwill',
+            'The moment you realize you believe your own cover story',
+            'The cost of defending someone who would not defend you'
+        ],
+        storyTriggers: [
+            "Sydney explains to the front desk why Oswaldo missed rent drop-off",
+            "She catches herself making his excuses to Trina before he can",
+            "Dex asks why she covers for him and she doesn't have an answer"
+        ],
+        unconventionalAngle: "You are not protecting him. You are protecting the version of him you need to believe in."
+    },
+    {
+        id: 20,
+        title: 'Competence as Silence',
+        quote: "You got so good at handling it that you erased the evidence. Now there's no crisis. Which means, to them, there's no problem.",
+        insight: "Prevention looks like nothing happened. Which means you did nothing. Which means there was nothing to do.",
+        emotionalStakes: [
+            'The paradox of skill making effort invisible',
+            'The anger of being dismissed precisely because you succeeded',
+            'No one saves you because no one sees you drowning'
+        ],
+        storyTriggers: [
+            "Sydney solves a problem before anyone else woke up",
+            "Oswaldo says 'see, it worked out' — because she made it work out",
+            "She lets one thing fail just to see if anyone notices"
+        ],
+        unconventionalAngle: "The only way to make the problem visible is to stop being the solution."
+    },
+    {
+        id: 21,
+        title: 'The Pity Trap',
+        quote: "When you're the one who has it together, any moment you show need gets read as either performance or failure.",
+        insight: "Pity and contempt live next door. Ask for help once and you either don't mean it or you've collapsed.",
+        emotionalStakes: [
+            'The isolation of competence — no one believes you need help',
+            'The double bind: either you are fine or you have failed',
+            'The loneliness of asking and being disbelieved'
+        ],
+        storyTriggers: [
+            "Sydney says she's not okay and nobody adjusts their plans",
+            "Oswaldo: 'You always land on your feet, I'm not worried about you'",
+            "She stops saying she needs help because it doesn't change anything"
+        ],
+        unconventionalAngle: "Your resilience is the cage. The better you are at surviving, the less anyone believes you need rescue."
+    },
+    {
+        id: 22,
+        title: 'The Witness Problem',
+        quote: "You need someone to see the work. But explaining the work is more work. And the explaining gets mistaken for complaining.",
+        insight: "The request for acknowledgment gets heard as a demand. The demand gets heard as ingratitude.",
+        emotionalStakes: [
+            'The exhaustion of narrating your own labor to people who benefit from it',
+            'Being labeled difficult for describing what is actually difficult',
+            'The silence you choose when talking makes it worse'
+        ],
+        storyTriggers: [
+            "Sydney starts to explain why she's tired and Oswaldo sighs",
+            "Trina: 'You always make such a big deal'",
+            "Sydney goes quiet because explaining costs more than absorbing"
+        ],
+        unconventionalAngle: "The work is invisible because making it visible costs you. So you keep it invisible. So it stays invisible."
+    },
+    {
+        id: 23,
+        title: 'The Energy Ledger',
+        quote: "You can give time without attention. You can give attention without care. They have been withdrawing from all three columns.",
+        insight: "Time, attention, and care are not the same resource. They have been spending all three and replenishing none.",
+        emotionalStakes: [
+            'The depletion that happens below the level of any single ask',
+            'The slow drain of being present for people who are absent for you',
+            'The moment you notice you are empty and cannot point to where it went'
+        ],
+        storyTriggers: [
+            "Sydney is physically in the room but already somewhere else",
+            "She realizes she has not had a full night of her own thoughts in weeks",
+            "Oswaldo asks what she's thinking and she says 'nothing'"
+        ],
+        unconventionalAngle: "You didn't lose it all at once. You gave it away in increments small enough that each one seemed fine."
+    },
+    {
+        id: 24,
+        title: 'Strategic Incompetence',
+        quote: "The fastest way to stop being asked to do something is to do it badly the first time. They learned this. You never did.",
+        insight: "Your high standards are the reason you got the job and the reason you can't quit it.",
+        emotionalStakes: [
+            'The trap of your own competence — too good to be allowed to stop',
+            'The resentment of watching others opt out through failure',
+            'The exhaustion of the person who cannot do things badly'
+        ],
+        storyTriggers: [
+            "Oswaldo tried once and blamed the tools",
+            "Sydney watches him get out of things by being unreliable",
+            "She considers doing the task badly on purpose, then can't"
+        ],
+        unconventionalAngle: "You are not more responsible. You are less able to tolerate the consequences of being bad at things."
+    },
+    {
+        id: 25,
+        title: 'The Debt Amnesia',
+        quote: "There is a specific type of person who remembers every favor they gave and forgets every favor they got. You are the other type.",
+        insight: "Your generosity is real. So is their amnesia. Neither fact cancels the other.",
+        emotionalStakes: [
+            'The anger of giving and watching it disappear without acknowledgment',
+            'The self-doubt of wondering if you imagined the giving',
+            'The clarity of seeing the asymmetry plainly and still not knowing what to do with it'
+        ],
+        storyTriggers: [
+            "Trina asks for something Sydney already gave her once before",
+            "Dex mentions a favor Sydney did for him like it was a coincidence",
+            "Sydney stops saying 'remember when I...' because no one does"
+        ],
+        unconventionalAngle: "Their amnesia is not a medical condition. It's a policy."
+    },
+    {
+        id: 26,
+        title: "The Room's Economy",
+        quote: "You are not in a relationship. You are in a household. A household has suppliers and consumers.",
+        insight: "The exchange rate in this room has never been equal. The question is whether you've named that or just absorbed it.",
+        emotionalStakes: [
+            'The clarity of seeing the transaction for what it is',
+            'The discomfort of naming something that everyone pretends is love',
+            'The specific loneliness of being the only one who knows the actual numbers'
+        ],
+        storyTriggers: [
+            "Sydney calculates: $65 rent, $40 food, $20 phone bills, $0 from anyone else",
+            "Oswaldo says 'what's mine is yours' — she has never seen his money",
+            "She does the math out loud just once and the room goes quiet"
+        ],
+        unconventionalAngle: "Call it what it is. Not because naming it changes it. Because you deserve to know what you are carrying."
+    },
+    {
+        id: 27,
+        title: 'The Loyalty Tariff',
+        quote: "Staying proves you're loyal. Leaving proves you were always going to leave. They've built a logic where you can't win.",
+        insight: "The system is designed so that any choice you make confirms what they already believe about you.",
+        emotionalStakes: [
+            'The trap of a frame where staying costs and leaving costs more',
+            'The exhaustion of being legible only as loyalty or betrayal',
+            'The moment you see the trap and are still inside it'
+        ],
+        storyTriggers: [
+            "Sydney thinks about leaving and immediately imagines Oswaldo's version of why",
+            "Trina: 'She's always threatening to leave but she never does'",
+            "Sydney realizes that the story they will tell about her is already written"
+        ],
+        unconventionalAngle: "You are not choosing between leaving and staying. You are choosing which story they get to tell about you."
     }
 ];
 
@@ -363,6 +534,18 @@ export function detectLessonInScene(sceneText: string): number | null {
     if (text.includes('risk') && text.includes('reduce')) return 16;
     if (text.includes("won't") && text.includes("can't")) return 13;
     if (text.includes('let it fail') || text.includes('let things break')) return 12;
+
+    // Lessons 18-27
+    if (text.includes("there's a ledger") || text.includes('keeping score') && text.includes('money')) return 18;
+    if (text.includes('cover story') || text.includes('making excuses for him')) return 19;
+    if (text.includes('no crisis') || text.includes('see it worked out')) return 20;
+    if (text.includes("always land on your feet") || text.includes("you'll figure it out") && text.includes("always")) return 21;
+    if (text.includes('making it worse') && text.includes('explain') || text.includes('big deal') && text.includes('complaining')) return 22;
+    if (text.includes('already somewhere else') || text.includes('what are you thinking') && text.includes("nothing")) return 23;
+    if (text.includes('did it badly') || text.includes('strategic') && text.includes("competence")) return 24;
+    if (text.includes("remember when") && (text.includes("trina") || text.includes("dex")) || text.includes("debt amnesia")) return 25;
+    if (text.includes("what's mine is yours") || text.includes("supplier") && text.includes("consumer")) return 26;
+    if (text.includes('always going to leave') || text.includes("loyalty tariff") || text.includes("story they will tell")) return 27;
 
     return null;
 }

--- a/src/lib/narrative/promptFormatting.ts
+++ b/src/lib/narrative/promptFormatting.ts
@@ -4,9 +4,6 @@ import type { Lesson } from '$lib/narrative/lessonsCatalog';
 export function formatLessonsForPrompt(lessons: Lesson[]): string {
 	return lessons
 		.map((lesson) => {
-			const stakes = Array.isArray(lesson.emotionalStakes)
-				? lesson.emotionalStakes.slice(0, 2).join(' | ')
-				: '';
 			const triggers = Array.isArray(lesson.storyTriggers)
 				? lesson.storyTriggers.slice(0, 2).join(' | ')
 				: '';
@@ -15,7 +12,6 @@ export function formatLessonsForPrompt(lessons: Lesson[]): string {
 			return `${lesson.id}. ${lesson.title}
    Quote: "${lesson.quote}"
    Core Insight: ${lesson.insight}
-   Emotional Stakes: ${stakes}
    Common Triggers: ${triggers}
    Unconventional Angle: ${unconventionalAngle}`;
 		})

--- a/src/lib/server/ai/builder/modelClient.ts
+++ b/src/lib/server/ai/builder/modelClient.ts
@@ -10,48 +10,81 @@ interface ChatResponse {
 	choices?: ChatChoice[];
 }
 
+async function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export async function callBuilderModel(systemPrompt: string, userPrompt: string): Promise<string> {
 	const config = loadAiConfig();
-	const controller = new AbortController();
-	const timeoutId = setTimeout(() => controller.abort(), config.requestTimeoutMs);
+	const maxAttempts = 1 + config.maxRetries;
+	let lastError: Error | null = null;
 
-	let response: Response;
-	try {
-		response = await fetch(XAI_CHAT_URL, {
-			method: 'POST',
-			headers: {
-				'content-type': 'application/json',
-				authorization: `Bearer ${config.xaiApiKey}`
-			},
-			body: JSON.stringify({
-				model: config.grokTextModel,
-				messages: [
-					{ role: 'system', content: systemPrompt },
-					{ role: 'user', content: userPrompt }
-				],
-				max_tokens: Math.min(config.maxOutputTokens, 1400),
-				temperature: 0.7
-			}),
-			signal: controller.signal
-		});
-	} catch (error) {
-		if (error instanceof Error && error.name === 'AbortError') {
-			throw new Error(`Builder model request timed out after ${config.requestTimeoutMs}ms`);
+	for (let attempt = 0; attempt < maxAttempts; attempt++) {
+		if (attempt > 0) {
+			const backoffMs =
+				config.retryBackoffMs[attempt - 1] ?? config.retryBackoffMs.at(-1) ?? 1200;
+			await sleep(backoffMs);
 		}
-		throw error;
-	} finally {
-		clearTimeout(timeoutId);
+
+		const controller = new AbortController();
+		const timeoutId = setTimeout(() => controller.abort(), config.requestTimeoutMs);
+		const startMs = Date.now();
+
+		try {
+			const response = await fetch(XAI_CHAT_URL, {
+				method: 'POST',
+				headers: {
+					'content-type': 'application/json',
+					authorization: `Bearer ${config.xaiApiKey}`
+				},
+				body: JSON.stringify({
+					model: config.grokTextModel,
+					messages: [
+						{ role: 'system', content: systemPrompt },
+						{ role: 'user', content: userPrompt }
+					],
+					max_tokens: config.builderMaxTokens,
+					temperature: config.builderTemperature
+				}),
+				signal: controller.signal
+			});
+			clearTimeout(timeoutId);
+
+			if (!response.ok) {
+				const err = new Error(`Builder model request failed (${response.status})`);
+				if (response.status >= 500 && attempt < maxAttempts - 1) {
+					lastError = err;
+					console.warn(`[provider_build] attempt=${attempt + 1} status=${response.status} retrying`);
+					continue;
+				}
+				throw err;
+			}
+
+			const payload = (await response.json()) as ChatResponse;
+			const text = payload.choices?.[0]?.message?.content;
+			if (!text || typeof text !== 'string') {
+				throw new Error('Builder model returned empty content');
+			}
+
+			const durationMs = Date.now() - startMs;
+			console.info(`[provider_build] ok attempt=${attempt + 1} duration_ms=${durationMs}`);
+			return text;
+		} catch (error) {
+			clearTimeout(timeoutId);
+			if (error instanceof Error && error.name === 'AbortError') {
+				const timeoutErr = new Error(
+					`Builder model request timed out after ${config.requestTimeoutMs}ms`
+				);
+				if (attempt < maxAttempts - 1) {
+					lastError = timeoutErr;
+					console.warn(`[provider_build] attempt=${attempt + 1} timeout retrying`);
+					continue;
+				}
+				throw timeoutErr;
+			}
+			throw error;
+		}
 	}
 
-	if (!response.ok) {
-		throw new Error(`Builder model request failed (${response.status})`);
-	}
-
-	const payload = (await response.json()) as ChatResponse;
-	const text = payload.choices?.[0]?.message?.content;
-	if (!text || typeof text !== 'string') {
-		throw new Error('Builder model returned empty content');
-	}
-
-	return text;
+	throw lastError ?? new Error('Builder model request failed after all retries');
 }

--- a/src/lib/server/ai/config.ts
+++ b/src/lib/server/ai/config.ts
@@ -18,6 +18,8 @@ export interface AiConfig {
 	requestTimeoutMs: number;
 	maxRetries: number;
 	retryBackoffMs: number[];
+	builderTemperature: number;
+	builderMaxTokens: number;
 }
 
 function parseBoolean(value: string | undefined, fallback: boolean): boolean {
@@ -31,6 +33,13 @@ function parseBoolean(value: string | undefined, fallback: boolean): boolean {
 function parseIntInRange(value: string | undefined, fallback: number, min: number, max: number): number {
 	if (typeof value !== 'string' || value.trim().length === 0) return fallback;
 	const parsed = Number.parseInt(value, 10);
+	if (!Number.isFinite(parsed)) return fallback;
+	return Math.min(max, Math.max(min, parsed));
+}
+
+function parseFloatInRange(value: string | undefined, fallback: number, min: number, max: number): number {
+	if (typeof value !== 'string' || value.trim().length === 0) return fallback;
+	const parsed = Number.parseFloat(value);
 	if (!Number.isFinite(parsed)) return fallback;
 	return Math.min(max, Math.max(min, parsed));
 }

--- a/src/lib/stories/no-vacancies/index.ts
+++ b/src/lib/stories/no-vacancies/index.ts
@@ -32,14 +32,13 @@ const imagePaths: Record<string, string> = {
 };
 
 const pregeneratedImagePool: string[] = [
-	'/images/ChatGPT Image Feb 7, 2026, 03_33_36 AM.png',
-	'/images/ChatGPT Image Feb 7, 2026, 03_33_55 AM.png',
-	'/images/ChatGPT Image Feb 7, 2026, 03_34_02 AM.png',
-	'/images/ChatGPT Image Feb 7, 2026, 03_34_07 AM.png',
-	'/images/ChatGPT Image Feb 7, 2026, 03_34_13 AM.png',
-	'/images/ChatGPT Image Feb 7, 2026, 03_34_20 AM.png',
+	'/images/chatgpt_image_feb_7_2026_03_33_36_am.png',
+	'/images/chatgpt_image_feb_7_2026_03_33_55_am.png',
+	'/images/chatgpt_image_feb_7_2026_03_34_02_am.png',
+	'/images/chatgpt_image_feb_7_2026_03_34_07_am.png',
+	'/images/chatgpt_image_feb_7_2026_03_34_13_am.png',
+	'/images/chatgpt_image_feb_7_2026_03_34_20_am.png',
 	'/images/car_memory.png',
-	'/images/convenience_store.png',
 	'/images/empty_room.png',
 	'/images/hotel_room.png',
 	'/images/motel_exterior.png',

--- a/src/lib/stories/no-vacancies/prompts.ts
+++ b/src/lib/stories/no-vacancies/prompts.ts
@@ -241,6 +241,14 @@ Sydney doesn't just "pay bills." She manages:
 ## VOICE CEILING EXAMPLES
 ${VOICE_CEILING_LINES.map((line) => `- "${line}"`).join('\n')}
 
+## BEHAVIOR SEEDS (enacted patterns — surface through incident; do not state the pattern directly)
+- Oswaldo: Rides five miles for Dex's smokes, then asks Sydney to DoorDash him water because he is "too sore" to walk to the machine. → Selectively allocates effort based on who validates him, not who needs him.
+- Dex: Listens like a friend, then her private complaint comes back from somebody else with different punctuation. → Concern is the entry fee; betrayal is the operating model.
+
+## COMBO STATE LINES (use when state conditions are met — do not force)
+- When exhaustion is high and the room is still unpaid: "She is too tired to be diplomatic and too broke to be gentle."
+- When Oswaldo conflict is high and awareness is still low: "He feels accused before he feels responsible."
+
 ## 17 LESSONS TO WEAVE IN
 Work them in naturally through situation, never lecture:
 - Write the scene first. Then label lessonId after the writing is done.


### PR DESCRIPTION
## Summary

Fixes carried forward from Sprint 3 plus all Sprint 4 (prompt wiring + model config) and Sprint 5 (lessons catalog expansion) work.

### Sprint 3 carry-over fix
- **`pregeneratedImagePool`** in `index.ts`: replaced 6 space-containing ChatGPT filenames with snake_case equivalents; removed deleted `convenience_store.png`

### Sprint 4 — Prompt wiring
- **Bug #1 (behaviorSeeds)**: Injected two authored behavioral fingerprints into `SYSTEM_PROMPT` via new `## BEHAVIOR SEEDS` section in `prompts.ts`
- **Bug #2 (emotionalStakes contamination)**: Removed `emotionalStakes` from `formatLessonsForPrompt()` in `promptFormatting.ts` — forbidden language no longer reaches the AI
- **Bug #4 (comboStateLines)**: Injected two state-combination trigger lines into `SYSTEM_PROMPT` via new `## COMBO STATE LINES` section in `prompts.ts`

### Sprint 4 — Model config
- **`config.ts`**: Added `builderTemperature` and `builderMaxTokens` fields driven by `BUILDER_TEMPERATURE` / `BUILDER_MAX_TOKENS` env vars with `parseFloatInRange` / `parseIntInRange` guards
- **`modelClient.ts`**: Full rewrite — retry loop (`1 + config.maxRetries` attempts), configurable back-off from `config.retryBackoffMs`, config-driven `temperature` and `max_tokens`, timeout abort, structured telemetry via `console.info/warn` with `[provider_build]` prefix

### Sprint 5 — Lessons catalog
- **Fixed 5 forbidden `emotionalStakes` entries** (lessons 2, 4, 5, 14, 17) — replaced `Realizing/Feeling/Wondering` language with concrete observational descriptions
- **Fixed 3 insights** (lessons 11, 14, 15) — rewritten to match the cold-observer voice
- **Added lessons 18–27**: The Emotional Accountant, The Cover Story, Competence as Silence, The Pity Trap, The Witness Problem, The Energy Ledger, Strategic Incompetence, The Debt Amnesia, The Room's Economy, The Loyalty Tariff
- **`detectLessonInScene()`** updated with keyword patterns for all 10 new lessons

## Test plan
- [ ] Verify Vercel preview build passes TypeScript check
- [ ] Spot-check `formatLessonsForPrompt()` output — confirm no `Emotional Stakes:` line in generated prompts
- [ ] Confirm `SYSTEM_PROMPT` in `prompts.ts` contains `## BEHAVIOR SEEDS` and `## COMBO STATE LINES` sections
- [ ] Set `BUILDER_TEMPERATURE=0.9` env var locally, confirm `config.ts` parses it correctly
- [ ] Trigger a story beat with `modelClient.ts` — confirm telemetry logs appear with `[provider_build]` prefix
- [ ] Confirm `lessonsCatalog.ts` exports 27 lessons