### PR TITLE
Sprint 6: auth shell — login page, logout, session passthrough, redirect guard

### DIFF
--- a/src/lib/server/middleware/builderAuth.ts
+++ b/src/lib/server/middleware/builderAuth.ts
@@ -1,10 +1,28 @@
-import type { Handle } from '@sveltejs/kit';
+import { redirect, type Handle } from '@sveltejs/kit';
 import { authErrorResponse, BUILDER_ROLES, getSessionUser, isBuilderRole } from '$lib/server/auth';
 import { emitAiServerTelemetry } from '$lib/server/ai/telemetry';
 
 function isBuilderProtectedRoute(path: string): boolean {
 	if (path === '/builder' || path.startsWith('/builder/')) return true;
 	return path.startsWith('/api/builder/');
+}
+
+/**
+ * Returns true when the request is an XHR / API call that expects a JSON response.
+ * These requests should receive structured JSON error bodies (401/403) rather than a
+ * redirect to the login page.
+ */
+function expectsJsonResponse(event: Parameters<Handle>[0]['event']): boolean {
+	// Requests to /api/* are always JSON consumers.
+	if (event.url.pathname.startsWith('/api/')) return true;
+	// Explicit content-type negotiation.
+	const accept = event.request.headers.get('accept') ?? '';
+	if (accept.includes('application/json')) return true;
+	// Conventional XHR sentinel.
+	if (event.request.headers.get('x-requested-with') === 'XMLHttpRequest') return true;
+	// SvelteKit's own data-fetching requests include this header.
+	if (event.request.headers.get('x-sveltekit-action') !== null) return true;
+	return false;
 }
 
 function emitBuilderAccessDenied(
@@ -29,6 +47,14 @@ export const builderAuth: Handle = async ({ event, resolve }) => {
 	if (isBuilderProtectedRoute(path)) {
 		if (!sessionUser) {
 			emitBuilderAccessDenied(path, 'auth_required', null);
+
+			// For browser navigation (accepts HTML), redirect to the login page so the
+			// user sees a friendly form instead of a raw JSON error.
+			if (!expectsJsonResponse(event)) {
+				const loginUrl = `/login?next=${encodeURIComponent(path)}`;
+				redirect(302, loginUrl);
+			}
+
 			return authErrorResponse({
 				status: 401,
 				code: 'auth_required',

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,0 +1,7 @@
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async ({ locals }) => {
+	return {
+		sessionUser: locals.sessionUser
+	};
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,6 +5,9 @@
 	import { registerPwaServiceWorker } from '$lib/client/pwa';
 	import { getSafeActiveStoryCartridge } from '$lib/stories';
 	import { selectStoryPresentation } from '$lib/stories/selectors';
+	import type { LayoutData } from './$types';
+
+	export let data: LayoutData;
 
 	const activeStory = getSafeActiveStoryCartridge();
 	const shellStoryTitle = activeStory?.title ?? 'Story Configuration Blocked';
@@ -86,6 +89,13 @@
 					<span>Debug</span>
 				</a>
 			{/if}
+			{#if data.sessionUser}
+				<form method="POST" action="/api/auth/logout" class="sign-out-form">
+					<button type="submit" class="sign-out-btn" title="Signed in as {data.sessionUser.role}">
+						Sign out
+					</button>
+				</form>
+			{/if}
 		</nav>
 	</header>
 
@@ -93,3 +103,27 @@
 		<slot />
 	</main>
 </div>
+
+<style>
+	.sign-out-form {
+		display: contents;
+	}
+
+	.sign-out-btn {
+		background: none;
+		border: 1px solid currentColor;
+		border-radius: 3px;
+		color: inherit;
+		cursor: pointer;
+		font-family: inherit;
+		font-size: 0.75rem;
+		letter-spacing: 0.04em;
+		opacity: 0.55;
+		padding: 0.2em 0.6em;
+		transition: opacity 0.15s;
+	}
+
+	.sign-out-btn:hover {
+		opacity: 1;
+	}
+</style>

--- a/src/routes/api/auth/logout/+server.ts
+++ b/src/routes/api/auth/logout/+server.ts
@@ -1,15 +1,8 @@
-import { json, type RequestHandler } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { SESSION_COOKIE_NAME } from '$lib/server/auth';
 
-import { SESSION_COOKIE_NAME, useSecureCookies } from '$lib/server/auth';
-
-export const POST: RequestHandler = async ({ cookies, url }) => {
-	cookies.set(SESSION_COOKIE_NAME, '', {
-		httpOnly: true,
-		secure: useSecureCookies(url),
-		sameSite: 'lax',
-		path: '/',
-		maxAge: 0
-	});
-
-	return json({ ok: true });
+export const POST: RequestHandler = async ({ cookies }) => {
+	cookies.delete(SESSION_COOKIE_NAME, { path: '/' });
+	redirect(302, '/login');
 };

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -1,0 +1,48 @@
+import { fail, redirect } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import {
+	createSignedSessionCookieValue,
+	getAuthSessionSecret,
+	isDemoAuthEnabled,
+	SESSION_COOKIE_NAME,
+	SESSION_MAX_AGE_SECONDS,
+	useSecureCookies
+} from '$lib/server/auth';
+
+export const load: PageServerLoad = async ({ locals, url }) => {
+	// Already authenticated — send them where they were headed (or builder).
+	if (locals.sessionUser) {
+		const next = url.searchParams.get('next') ?? '/builder';
+		redirect(302, next);
+	}
+	return { demoEnabled: isDemoAuthEnabled() };
+};
+
+export const actions: Actions = {
+	demoSignIn: async ({ cookies, url }) => {
+		if (!isDemoAuthEnabled()) {
+			return fail(403, { error: 'Demo authentication is not enabled on this instance.' });
+		}
+
+		const secret = getAuthSessionSecret();
+		if (!secret) {
+			return fail(500, { error: 'Authentication is not configured. Set AUTH_SESSION_SECRET.' });
+		}
+
+		const cookieValue = await createSignedSessionCookieValue(
+			{ userId: 'demo-author', role: 'author' },
+			secret
+		);
+
+		cookies.set(SESSION_COOKIE_NAME, cookieValue, {
+			path: '/',
+			httpOnly: true,
+			secure: useSecureCookies(url),
+			sameSite: 'lax',
+			maxAge: SESSION_MAX_AGE_SECONDS
+		});
+
+		const next = url.searchParams.get('next') ?? '/builder';
+		redirect(302, next);
+	}
+};

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import type { PageData, ActionData } from './$types';
+
+	export let data: PageData;
+	export let form: ActionData;
+</script>
+
+<svelte:head>
+	<title>Sign in — No Vacancies</title>
+	<meta name="description" content="Sign in to access the No Vacancies story builder." />
+</svelte:head>
+
+<div class="login-shell">
+	<div class="login-card">
+		<header class="login-header">
+			<p class="login-kicker">No Vacancies / builder access</p>
+			<h1 class="login-title">Sign in</h1>
+			<p class="login-sub">
+				The story builder is a restricted tool. Sign in to continue.
+			</p>
+		</header>
+
+		{#if form?.error}
+			<p class="login-error" role="alert">{form.error}</p>
+		{/if}
+
+		{#if data.demoEnabled}
+			<form method="POST" action="?/demoSignIn" use:enhance class="login-form">
+				<button type="submit" class="login-btn-primary">
+					Enter as author (demo mode)
+				</button>
+			</form>
+			<p class="login-notice">
+				Demo mode is active. This grants <code>author</code> access without password verification.
+				Disable <code>DEMO_AUTH_ENABLED</code> in production.
+			</p>
+		{:else}
+			<div class="login-unavailable">
+				<p>
+					Full authentication is not yet enabled on this instance. Supabase-backed login
+					arrives in a later sprint.
+				</p>
+				<p class="login-notice">
+					To unlock the builder locally, set <code>DEMO_AUTH_ENABLED=1</code> and
+					<code>AUTH_SESSION_SECRET</code> in your <code>.env</code>.
+				</p>
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.login-shell {
+		min-height: 100vh;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 2rem 1rem;
+	}
+
+	.login-card {
+		width: 100%;
+		max-width: 420px;
+		border: 1px solid var(--color-border, #2a2a2a);
+		border-radius: 6px;
+		padding: 2.5rem 2rem;
+		background: var(--color-surface, #111);
+	}
+
+	.login-header {
+		margin-bottom: 1.75rem;
+	}
+
+	.login-kicker {
+		font-size: 0.7rem;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--color-muted, #666);
+		margin: 0 0 0.5rem;
+	}
+
+	.login-title {
+		font-size: 1.5rem;
+		font-weight: 600;
+		margin: 0 0 0.5rem;
+		line-height: 1.2;
+	}
+
+	.login-sub {
+		font-size: 0.875rem;
+		color: var(--color-muted, #888);
+		margin: 0;
+		line-height: 1.5;
+	}
+
+	.login-error {
+		background: color-mix(in srgb, red 12%, transparent);
+		border: 1px solid color-mix(in srgb, red 30%, transparent);
+		border-radius: 4px;
+		color: #f87171;
+		font-size: 0.875rem;
+		margin: 0 0 1rem;
+		padding: 0.625rem 0.875rem;
+	}
+
+	.login-form {
+		margin-bottom: 1rem;
+	}
+
+	.login-btn-primary {
+		display: block;
+		width: 100%;
+		padding: 0.75rem 1rem;
+		background: var(--color-accent, #e8e8e8);
+		color: var(--color-bg, #0a0a0a);
+		border: none;
+		border-radius: 4px;
+		font-size: 0.9rem;
+		font-weight: 600;
+		cursor: pointer;
+		transition: opacity 0.15s;
+	}
+
+	.login-btn-primary:hover {
+		opacity: 0.88;
+	}
+
+	.login-btn-primary:active {
+		opacity: 0.75;
+	}
+
+	.login-notice {
+		font-size: 0.75rem;
+		color: var(--color-muted, #666);
+		line-height: 1.5;
+		margin: 0.75rem 0 0;
+	}
+
+	.login-notice code {
+		font-family: monospace;
+		background: var(--color-surface-raised, #1c1c1c);
+		padding: 0.1em 0.3em;
+		border-radius: 2px;
+	}
+
+	.login-unavailable {
+		font-size: 0.875rem;
+		color: var(--color-muted, #888);
+		line-height: 1.6;
+	}
+
+	.login-unavailable p {
+		margin: 0 0 0.75rem;
+	}
+</style>


### PR DESCRIPTION
## Summary

- **Login page** (`src/routes/login/`): server `load` bounces already-authenticated users; `demoSignIn` action creates a signed `nv_session` HMAC cookie when `DEMO_AUTH_ENABLED=1`
- **Logout endpoint** (`src/routes/api/auth/logout/+server.ts`): POST clears the cookie and 302s to `/login`
- **Layout server** (`src/routes/+layout.server.ts`): forwards `sessionUser` from `locals` into `LayoutData` so all pages can read it
- **Layout update** (`+layout.svelte`): consumes `LayoutData`; renders a "Sign out" button in the nav whenever `data.sessionUser` is set
- **builderAuth redirect** (`src/lib/server/middleware/builderAuth.ts`): unauthenticated browser GETs to `/builder` now redirect to `/login?next=/builder` instead of returning raw JSON 401; XHR / API requests still receive the structured JSON 401 body

## Test plan
- [ ] Navigate to `/builder` while logged out → should redirect to `/login?next=%2Fbuilder`
- [ ] On login page with `DEMO_AUTH_ENABLED=1`, click "Enter as author" → cookie set → redirect to `/builder`
- [ ] Sign Out button visible in nav on builder route; clicking it clears cookie and redirects to `/login`
- [ ] `fetch('/api/builder/generate-draft', ...)` without session → 401 JSON (not a redirect)
- [ ] Vercel preview build passes TypeScript check