### PR TITLE
Sprint 7: PostHog + Sentry observability

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@rollup/rollup-linux-x64-gnu": "^4.57.1",
+    "@sentry/sveltekit": "^9.17.0",
     "@sveltejs/adapter-vercel": "^6.3.2",
     "@sveltejs/kit": "^2.48.4",
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
@@ -42,6 +43,8 @@
     "http-server": "^14.1.1",
     "jsdom": "^28.0.0",
     "nodemon": "^3.1.11",
+    "posthog-js": "^1.240.6",
+    "posthog-node": "^4.8.1",
     "prettier": "^3.8.1",
     "svelte": "^5.43.3",
     "svelte-check": "^4.3.3",

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,0 +1,28 @@
+/**
+ * SvelteKit client-side hooks.
+ *
+ * Initialises Sentry in the browser for client-side error monitoring and
+ * wraps the default error handler so unhandled client exceptions are
+ * captured automatically.
+ *
+ * Required env vars (public — injected at build time):
+ *   PUBLIC_SENTRY_DSN — Sentry DSN for client-side error capture.
+ *                       If absent, falls back to the default console error handler.
+ */
+import * as Sentry from '@sentry/sveltekit';
+import { handleErrorWithSentry } from '@sentry/sveltekit';
+import { PUBLIC_SENTRY_DSN } from '$env/static/public';
+
+if (PUBLIC_SENTRY_DSN) {
+	Sentry.init({
+		dsn: PUBLIC_SENTRY_DSN,
+		environment: import.meta.env.MODE,
+		tracesSampleRate: 0.1,
+		// Replay recording for a sample of sessions to aid debugging.
+		replaysSessionSampleRate: 0.05,
+		replaysOnErrorSampleRate: 1.0,
+		integrations: [Sentry.replayIntegration()]
+	});
+}
+
+export const handleError = handleErrorWithSentry();

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,9 +1,21 @@
 import { sequence } from '@sveltejs/kit/hooks';
+import { sentryHandle, handleErrorWithSentry } from '@sentry/sveltekit';
 
+import { initSentry } from '$lib/server/observability/sentry';
 import { aiRateLimit } from '$lib/server/middleware/aiRateLimit';
 import { securityHeaders } from '$lib/server/middleware/securityHeaders';
 import { builderAuth } from '$lib/server/middleware/builderAuth';
 
-// securityHeaders is listed first so it wraps all subsequent handlers — this ensures
-// that even 429 rate-limit and 401/403 auth responses receive the baseline security headers.
-export const handle = sequence(securityHeaders, builderAuth, aiRateLimit);
+// Initialize Sentry as early as possible — before any request handling begins.
+// No-op when SENTRY_DSN is absent so local dev works without credentials.
+initSentry();
+
+// sentryHandle() is listed first so that every request receives a Sentry trace
+// context header, enabling end-to-end distributed tracing from client to server.
+// securityHeaders wraps all subsequent handlers so even Sentry-emitted error
+// responses carry the baseline security headers.
+export const handle = sequence(sentryHandle(), securityHeaders, builderAuth, aiRateLimit);
+
+// Capture any unhandled server errors in Sentry and pass a sanitised error id
+// back to the client. Falls back to the default handler when Sentry is absent.
+export const handleError = handleErrorWithSentry();

--- a/src/lib/client/analytics/posthog.ts
+++ b/src/lib/client/analytics/posthog.ts
@@ -1,0 +1,69 @@
+/**
+ * Client-side PostHog analytics integration.
+ *
+ * Required env var (SvelteKit public env, replace at build time):
+ *   PUBLIC_POSTHOG_API_KEY — Project API key from your PostHog project settings.
+ *                            If absent or empty, all functions are no-ops.
+ *
+ * Usage:
+ *   import { initPosthog, capturePageview, captureEvent } from '$lib/client/analytics/posthog';
+ *   // Call initPosthog once in +layout.svelte onMount
+ *   // Call capturePageview on $page store changes
+ */
+import posthog from 'posthog-js';
+import type { PostHog } from 'posthog-js';
+
+let instance: PostHog | null = null;
+
+/**
+ * Initialize PostHog. Safe to call multiple times — subsequent calls are no-ops.
+ * No-op when apiKey is absent/empty, or when called outside a browser context.
+ */
+export function initPosthog(apiKey: string | undefined): void {
+	if (instance !== null) return;
+	if (!apiKey || typeof window === 'undefined') return;
+
+	posthog.init(apiKey, {
+		api_host: 'https://us.i.posthog.com',
+		// We capture pageviews manually to align with SvelteKit's client-side routing.
+		capture_pageview: false,
+		// Track sessions without cookies where possible.
+		persistence: 'localStorage+cookie',
+		// Respect Do Not Track headers.
+		respect_dnt: true,
+		// Boot fast; load feature flags in the background.
+		bootstrap: {}
+	});
+	instance = posthog;
+}
+
+/**
+ * Capture a custom event. No-op when PostHog is not initialised.
+ */
+export function captureEvent(event: string, properties?: Record<string, unknown>): void {
+	instance?.capture(event, properties);
+}
+
+/**
+ * Capture a pageview for the current route. Call this on each client-side
+ * navigation (react to $page.url.pathname changes in the layout).
+ */
+export function capturePageview(path: string): void {
+	instance?.capture('$pageview', {
+		$current_url: typeof window !== 'undefined' ? window.location.href : path
+	});
+}
+
+/**
+ * Identify the current user. Call this after sign-in when a userId is known.
+ */
+export function identifyUser(userId: string, traits?: Record<string, unknown>): void {
+	instance?.identify(userId, traits);
+}
+
+/**
+ * Reset the PostHog identity. Call this on sign-out.
+ */
+export function resetPosthog(): void {
+	instance?.reset();
+}

--- a/src/lib/server/observability/sentry.ts
+++ b/src/lib/server/observability/sentry.ts
@@ -1,0 +1,67 @@
+/**
+ * Server-side Sentry integration.
+ *
+ * Required env vars:
+ *   SENTRY_DSN  — Data Source Name from your Sentry project settings.
+ *                 If absent, all functions are no-ops; the app runs normally.
+ *
+ * Usage:
+ *   import { initSentry, captureServerException } from '$lib/server/observability/sentry';
+ *   initSentry();  // call once, early in hooks.server.ts
+ */
+import * as Sentry from '@sentry/sveltekit';
+
+let initialized = false;
+
+function getSentryDsn(): string | undefined {
+	const runtimeProcess = globalThis as {
+		process?: { env?: Record<string, string | undefined> };
+	};
+	return runtimeProcess.process?.env?.SENTRY_DSN;
+}
+
+function getSentryEnv(): string {
+	const runtimeProcess = globalThis as {
+		process?: { env?: Record<string, string | undefined> };
+	};
+	return runtimeProcess.process?.env?.VERCEL_ENV ?? 'development';
+}
+
+/**
+ * Initialize Sentry once per server cold start. Safe to call multiple times —
+ * subsequent calls are no-ops. No-op when SENTRY_DSN is absent.
+ */
+export function initSentry(): void {
+	if (initialized) return;
+	const dsn = getSentryDsn();
+	if (!dsn) {
+		initialized = true; // Mark so we don't keep trying
+		return;
+	}
+	Sentry.init({
+		dsn,
+		environment: getSentryEnv(),
+		// Capture 10% of requests for performance tracing. Raise in production
+		// once you understand your volume.
+		tracesSampleRate: 0.1,
+		// Do not send personally identifiable information in breadcrumbs.
+		sendDefaultPii: false,
+		integrations: [],
+		enabled: true
+	});
+	initialized = true;
+}
+
+/**
+ * Capture a server-side exception with optional context. No-op when Sentry is
+ * not initialised (SENTRY_DSN absent).
+ */
+export function captureServerException(
+	error: unknown,
+	context?: Record<string, unknown>
+): string | undefined {
+	if (!getSentryDsn()) return undefined;
+	return Sentry.captureException(error, context ? { extra: context } : undefined);
+}
+
+export { Sentry };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { browser } from '$app/environment';
 	import { page } from '$app/stores';
 	import '../app.css';
 	import { registerPwaServiceWorker } from '$lib/client/pwa';
 	import { getSafeActiveStoryCartridge } from '$lib/stories';
 	import { selectStoryPresentation } from '$lib/stories/selectors';
+	import { initPosthog, capturePageview, identifyUser } from '$lib/client/analytics/posthog';
+	import { PUBLIC_POSTHOG_API_KEY } from '$env/static/public';
 	import type { LayoutData } from './$types';
 
 	export let data: LayoutData;
@@ -22,9 +25,31 @@
 		storyBriefItems: ['Check Story Selection in settings to resolve cartridge configuration.']
 	});
 
+	// Track the last pathname we sent a pageview for to avoid double-firing on initial load.
+	let lastTrackedPath = '';
+
 	onMount(() => {
 		registerPwaServiceWorker();
+
+		// Initialise PostHog. No-op when PUBLIC_POSTHOG_API_KEY is absent.
+		initPosthog(PUBLIC_POSTHOG_API_KEY);
+
+		// Capture the initial pageview.
+		lastTrackedPath = $page.url.pathname;
+		capturePageview($page.url.pathname);
+
+		// If a session user is known at load time, identify them in PostHog so
+		// events are attributed correctly from the first interaction.
+		if (data.sessionUser) {
+			identifyUser(data.sessionUser.userId, { role: data.sessionUser.role });
+		}
 	});
+
+	// Capture subsequent client-side navigations as pageviews.
+	$: if (browser && $page.url.pathname !== lastTrackedPath) {
+		lastTrackedPath = $page.url.pathname;
+		capturePageview($page.url.pathname);
+	}
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## Summary

- **package.json**: adds `@sentry/sveltekit ^9.17`, `posthog-js ^1.240`, `posthog-node ^4.8`
- **`src/lib/server/observability/sentry.ts`** (new): `initSentry()` and `captureServerException()` — no-ops when `SENTRY_DSN` env var is absent
- **`src/lib/client/analytics/posthog.ts`** (new): `initPosthog`, `capturePageview`, `captureEvent`, `identifyUser`, `resetPosthog` — no-ops when `PUBLIC_POSTHOG_API_KEY` is absent
- **`src/hooks.client.ts`** (new): client-side Sentry init with Replay (5% session, 100% error) + `handleErrorWithSentry`
- **`src/hooks.server.ts`** (modified): `initSentry()` at cold start, `sentryHandle()` added to sequence, `handleErrorWithSentry` exported as `handleError`
- **`src/routes/+layout.svelte`** (modified): `initPosthog` on mount, `capturePageview` on route change, `identifyUser` when session user is known

## Env vars needed (not in repo — set in Vercel dashboard)
| Var | Where | Purpose |
|---|---|---|
| `SENTRY_DSN` | server only | Sentry error capture |
| `PUBLIC_SENTRY_DSN` | public | Client-side Sentry |
| `PUBLIC_POSTHOG_API_KEY` | public | PostHog analytics |

## Test plan
- [ ] `npm install` succeeds with new SDK versions
- [ ] App builds (`npm run build`) without errors when env vars are absent
- [ ] Page navigations captured in PostHog when `PUBLIC_POSTHOG_API_KEY` set
- [ ] Server errors captured in Sentry when `SENTRY_DSN` set
- [ ] Vercel preview build passes TypeScript check