### PR TITLE
Sprint 8: Supabase repository layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@playwright/test": "^1.58.2",
     "@rollup/rollup-linux-x64-gnu": "^4.57.1",
     "@sentry/sveltekit": "^9.17.0",
+    "@supabase/supabase-js": "^2.49.4",
     "@sveltejs/adapter-vercel": "^6.3.2",
     "@sveltejs/kit": "^2.48.4",
     "@sveltejs/vite-plugin-svelte": "^6.2.1",

--- a/src/lib/server/db/builderRepository.ts
+++ b/src/lib/server/db/builderRepository.ts
@@ -1,0 +1,121 @@
+/**
+ * Builder-draft repository.
+ *
+ * Cloud-syncs builder drafts so authors can continue across devices.
+ * localStorage remains the primary store; this layer adds durability and
+ * cross-device continuity for authenticated users.
+ *
+ * All functions return null / void when the Supabase client is unavailable.
+ */
+import { getSupabaseClient } from './supabase';
+import type { BuilderStoryDraft } from '$lib/stories/types';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function logDbError(operation: string, error: unknown): void {
+	console.error(
+		`[db:builder] ${operation} failed:`,
+		error instanceof Error ? error.message : error
+	);
+}
+
+// ─── Repository ───────────────────────────────────────────────────────────────
+
+/**
+ * Upsert a builder draft to the database.
+ * The unique constraint is (user_id, story_id) — one draft per user per story.
+ */
+export async function saveBuilderDraftToDb(
+	userId: string,
+	storyId: string,
+	draft: BuilderStoryDraft
+): Promise<void> {
+	const client = getSupabaseClient();
+	if (!client) return;
+
+	const { error } = await client.from('builder_drafts').upsert(
+		{
+			user_id: userId,
+			story_id: storyId,
+			draft: draft as unknown as Record<string, unknown>
+		},
+		{ onConflict: 'user_id,story_id', ignoreDuplicates: false }
+	);
+
+	if (error) {
+		logDbError('saveBuilderDraftToDb', error);
+	}
+}
+
+/**
+ * Load a saved builder draft.
+ * Returns null if no draft exists for this user/story or if the DB is unavailable.
+ */
+export async function loadBuilderDraftFromDb(
+	userId: string,
+	storyId: string
+): Promise<BuilderStoryDraft | null> {
+	const client = getSupabaseClient();
+	if (!client) return null;
+
+	const { data: row, error } = await client
+		.from('builder_drafts')
+		.select('draft')
+		.eq('user_id', userId)
+		.eq('story_id', storyId)
+		.maybeSingle();
+
+	if (error) {
+		logDbError('loadBuilderDraftFromDb', error);
+		return null;
+	}
+	if (!row) return null;
+
+	// Runtime cast — the DB JSONB column stores the full BuilderStoryDraft shape.
+	return row.draft as unknown as BuilderStoryDraft;
+}
+
+/**
+ * Delete a builder draft (e.g. when an author publishes or resets).
+ */
+export async function deleteBuilderDraft(userId: string, storyId: string): Promise<void> {
+	const client = getSupabaseClient();
+	if (!client) return;
+
+	const { error } = await client
+		.from('builder_drafts')
+		.delete()
+		.eq('user_id', userId)
+		.eq('story_id', storyId);
+
+	if (error) {
+		logDbError('deleteBuilderDraft', error);
+	}
+}
+
+/**
+ * List all builder drafts for a user. Useful for a "my stories" index.
+ */
+export async function listBuilderDraftsForUser(
+	userId: string
+): Promise<{ storyId: string; draft: BuilderStoryDraft; updatedAt: string }[]> {
+	const client = getSupabaseClient();
+	if (!client) return [];
+
+	const { data: rows, error } = await client
+		.from('builder_drafts')
+		.select('story_id, draft, updated_at')
+		.eq('user_id', userId)
+		.order('updated_at', { ascending: false });
+
+	if (error) {
+		logDbError('listBuilderDraftsForUser', error);
+		return [];
+	}
+
+	return (rows ?? []).map((row) => ({
+		storyId: row.story_id,
+		draft: row.draft as unknown as BuilderStoryDraft,
+		updatedAt: row.updated_at
+	}));
+}

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -1,0 +1,61 @@
+/**
+ * TypeScript types for the Supabase database schema.
+ *
+ * These mirror the SQL tables defined in
+ * supabase/migrations/20260510000000_initial_schema.sql
+ * and follow the Supabase generated-types convention so they can be replaced
+ * by `supabase gen types typescript` once the project is provisioned.
+ */
+
+// ─── Row shapes (what SELECT returns) ────────────────────────────────────────
+
+export interface PlaySessionRow {
+	id: string;
+	user_id: string;
+	story_id: string;
+	scene_id: string | null;
+	beat_count: number;
+	/** Serialised GameState (see src/lib/contracts/game.ts) */
+	game_state: Record<string, unknown>;
+	/** Serialised StoryThreads or null before the first beat */
+	threads: Record<string, unknown> | null;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface BuilderDraftRow {
+	id: string;
+	user_id: string;
+	story_id: string;
+	/** Serialised BuilderStoryDraft (see src/lib/stories/types.ts) */
+	draft: Record<string, unknown>;
+	created_at: string;
+	updated_at: string;
+}
+
+// ─── Insert / Update shapes ───────────────────────────────────────────────────
+
+export type PlaySessionInsert = Omit<PlaySessionRow, 'id' | 'created_at' | 'updated_at'>;
+export type PlaySessionUpdate = Partial<Omit<PlaySessionRow, 'id' | 'created_at'>>;
+
+export type BuilderDraftInsert = Omit<BuilderDraftRow, 'id' | 'created_at' | 'updated_at'>;
+export type BuilderDraftUpdate = Partial<Omit<BuilderDraftRow, 'id' | 'created_at'>>;
+
+// ─── Database type (passed to createClient<Database>()) ──────────────────────
+
+export interface Database {
+	public: {
+		Tables: {
+			play_sessions: {
+				Row: PlaySessionRow;
+				Insert: PlaySessionInsert;
+				Update: PlaySessionUpdate;
+			};
+			builder_drafts: {
+				Row: BuilderDraftRow;
+				Insert: BuilderDraftInsert;
+				Update: BuilderDraftUpdate;
+			};
+		};
+	};
+}

--- a/src/lib/server/db/sessionRepository.ts
+++ b/src/lib/server/db/sessionRepository.ts
@@ -1,0 +1,156 @@
+/**
+ * Play-session repository.
+ *
+ * Persists and retrieves a user's progress through a story in the
+ * `play_sessions` Supabase table.
+ *
+ * All functions return null / void (instead of throwing) when the Supabase
+ * client is unavailable so callers can treat the DB as optional.
+ */
+import { getSupabaseClient } from './supabase';
+import type { GameState, StoryThreads } from '$lib/contracts';
+
+// ─── Domain types ─────────────────────────────────────────────────────────────
+
+export interface PlaySessionData {
+	userId: string;
+	storyId: string;
+	sceneId?: string | null;
+	beatCount?: number;
+	gameState: GameState;
+	threads?: StoryThreads | null;
+}
+
+export interface StoredPlaySession extends PlaySessionData {
+	id: string;
+	createdAt: string;
+	updatedAt: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function logDbError(operation: string, error: unknown): void {
+	console.error(`[db:session] ${operation} failed:`, error instanceof Error ? error.message : error);
+}
+
+// ─── Repository ───────────────────────────────────────────────────────────────
+
+/**
+ * Upsert (create-or-update) a play session row.
+ * The unique constraint is (user_id, story_id) — one active session per user
+ * per story. Returns the row id on success, null if the DB is unavailable.
+ */
+export async function upsertPlaySession(data: PlaySessionData): Promise<string | null> {
+	const client = getSupabaseClient();
+	if (!client) return null;
+
+	const { data: rows, error } = await client
+		.from('play_sessions')
+		.upsert(
+			{
+				user_id: data.userId,
+				story_id: data.storyId,
+				scene_id: data.sceneId ?? null,
+				beat_count: data.beatCount ?? 0,
+				game_state: data.gameState as Record<string, unknown>,
+				threads: (data.threads ?? null) as Record<string, unknown> | null
+			},
+			{ onConflict: 'user_id,story_id', ignoreDuplicates: false }
+		)
+		.select('id')
+		.limit(1)
+		.single();
+
+	if (error) {
+		logDbError('upsertPlaySession', error);
+		return null;
+	}
+	return rows?.id ?? null;
+}
+
+/**
+ * Load the saved play session for a given user + story.
+ * Returns null if no session exists or the DB is unavailable.
+ */
+export async function loadPlaySession(
+	userId: string,
+	storyId: string
+): Promise<StoredPlaySession | null> {
+	const client = getSupabaseClient();
+	if (!client) return null;
+
+	const { data: row, error } = await client
+		.from('play_sessions')
+		.select('*')
+		.eq('user_id', userId)
+		.eq('story_id', storyId)
+		.maybeSingle();
+
+	if (error) {
+		logDbError('loadPlaySession', error);
+		return null;
+	}
+	if (!row) return null;
+
+	return {
+		id: row.id,
+		userId: row.user_id,
+		storyId: row.story_id,
+		sceneId: row.scene_id,
+		beatCount: row.beat_count,
+		gameState: row.game_state as unknown as GameState,
+		threads: row.threads as unknown as StoryThreads | null,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at
+	};
+}
+
+/**
+ * Delete a play session (e.g. when the user restarts from the beginning).
+ */
+export async function deletePlaySession(userId: string, storyId: string): Promise<void> {
+	const client = getSupabaseClient();
+	if (!client) return;
+
+	const { error } = await client
+		.from('play_sessions')
+		.delete()
+		.eq('user_id', userId)
+		.eq('story_id', storyId);
+
+	if (error) {
+		logDbError('deletePlaySession', error);
+	}
+}
+
+/**
+ * Return all stored sessions for a user (e.g. for a "continue where you
+ * left off" list). Returns an empty array if the DB is unavailable.
+ */
+export async function listPlaySessionsForUser(userId: string): Promise<StoredPlaySession[]> {
+	const client = getSupabaseClient();
+	if (!client) return [];
+
+	const { data: rows, error } = await client
+		.from('play_sessions')
+		.select('*')
+		.eq('user_id', userId)
+		.order('updated_at', { ascending: false });
+
+	if (error) {
+		logDbError('listPlaySessionsForUser', error);
+		return [];
+	}
+
+	return (rows ?? []).map((row) => ({
+		id: row.id,
+		userId: row.user_id,
+		storyId: row.story_id,
+		sceneId: row.scene_id,
+		beatCount: row.beat_count,
+		gameState: row.game_state as unknown as GameState,
+		threads: row.threads as unknown as StoryThreads | null,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at
+	}));
+}

--- a/src/lib/server/db/supabase.ts
+++ b/src/lib/server/db/supabase.ts
@@ -1,0 +1,58 @@
+/**
+ * Supabase server-side client (service-role key).
+ *
+ * Required env vars (server-only — never expose to the browser):
+ *   SUPABASE_URL              — Project URL, e.g. https://xxxx.supabase.co
+ *   SUPABASE_SERVICE_ROLE_KEY — Service-role key (bypasses RLS on the server)
+ *
+ * When either var is absent the factory returns null and every repository
+ * function becomes a no-op, so the app runs normally without a database
+ * during local development.
+ */
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from './schema';
+
+type NVClient = SupabaseClient<Database>;
+
+function getRuntimeEnv(key: string): string | undefined {
+	const runtimeProcess = globalThis as {
+		process?: { env?: Record<string, string | undefined> };
+	};
+	return runtimeProcess.process?.env?.[key];
+}
+
+let cached: NVClient | null = null;
+let unavailable = false; // set once we know the env vars are absent
+
+/**
+ * Returns the Supabase client, creating it lazily on first call.
+ * Returns null when SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY are missing.
+ */
+export function getSupabaseClient(): NVClient | null {
+	if (cached) return cached;
+	if (unavailable) return null;
+
+	const url = getRuntimeEnv('SUPABASE_URL');
+	const key = getRuntimeEnv('SUPABASE_SERVICE_ROLE_KEY');
+
+	if (!url || !key) {
+		unavailable = true;
+		return null;
+	}
+
+	cached = createClient<Database>(url, key, {
+		auth: {
+			// Never persist the service-role session in memory — it does not
+			// represent a user and must not appear in cookie/storage.
+			persistSession: false,
+			autoRefreshToken: false
+		}
+	});
+	return cached;
+}
+
+/** Reset the cached client (useful in test teardown). */
+export function resetSupabaseClient(): void {
+	cached = null;
+	unavailable = false;
+}

--- a/supabase/migrations/20260510000000_initial_schema.sql
+++ b/supabase/migrations/20260510000000_initial_schema.sql
@@ -1,0 +1,97 @@
+-- Migration: 20260510000000_initial_schema
+-- Creates the core persistence tables for No Vacancies.
+-- Apply with: supabase db push  (or via the Supabase dashboard SQL editor)
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- PLAY SESSIONS
+-- Stores each user's in-progress or completed run through a story.
+-- One row per (user_id, story_id) pair is the intended steady state — the
+-- repository upserts on that composite key via a separate index constraint.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.play_sessions (
+  id          UUID        DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id     TEXT        NOT NULL,
+  story_id    TEXT        NOT NULL,
+  scene_id    TEXT,
+  beat_count  INTEGER     NOT NULL DEFAULT 0,
+  -- Full game state snapshot (GameState contract serialised as JSON)
+  game_state  JSONB       NOT NULL DEFAULT '{}'::jsonb,
+  -- Narrative thread counters (StoryThreads contract serialised as JSON)
+  threads     JSONB,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- Enforce one active session per user per story
+  CONSTRAINT play_sessions_user_story_unique UNIQUE (user_id, story_id)
+);
+
+CREATE INDEX IF NOT EXISTS play_sessions_user_id_idx ON public.play_sessions (user_id);
+
+ALTER TABLE public.play_sessions ENABLE ROW LEVEL SECURITY;
+
+-- Service-role calls (server side) bypass RLS automatically.
+-- Anon / authenticated role policies will be tightened when Supabase Auth
+-- is wired up in a later sprint. For now we deny all direct client access
+-- so the only path is through our own server-side repository layer.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'play_sessions' AND policyname = 'deny_all_client_access'
+  ) THEN
+    CREATE POLICY deny_all_client_access ON public.play_sessions
+      FOR ALL USING (false);
+  END IF;
+END;
+$$;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- BUILDER DRAFTS
+-- Cloud-synced copy of the builder draft (localStorage is still the primary
+-- store for offline/dev; this row enables cross-device continuity and recovery).
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.builder_drafts (
+  id          UUID        DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id     TEXT        NOT NULL,
+  story_id    TEXT        NOT NULL,
+  -- Full BuilderStoryDraft serialised as JSON
+  draft       JSONB       NOT NULL DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT builder_drafts_user_story_unique UNIQUE (user_id, story_id)
+);
+
+CREATE INDEX IF NOT EXISTS builder_drafts_user_id_idx ON public.builder_drafts (user_id);
+
+ALTER TABLE public.builder_drafts ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'builder_drafts' AND policyname = 'deny_all_client_access'
+  ) THEN
+    CREATE POLICY deny_all_client_access ON public.builder_drafts
+      FOR ALL USING (false);
+  END IF;
+END;
+$$;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- updated_at trigger
+-- Automatically stamps updated_at on every row mutation.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE TRIGGER play_sessions_set_updated_at
+  BEFORE UPDATE ON public.play_sessions
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE OR REPLACE TRIGGER builder_drafts_set_updated_at
+  BEFORE UPDATE ON public.builder_drafts
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();


### PR DESCRIPTION
## Summary

Full Supabase persistence layer. DB provisioning (creating the Supabase project and running the migration) is a separate step — all code is no-op when `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` are absent.

### Schema (`supabase/migrations/20260510000000_initial_schema.sql`)
- `play_sessions` — one row per `(user_id, story_id)`, stores `game_state` + `threads` as JSONB, RLS enabled with deny-all anon policy
- `builder_drafts` — one row per `(user_id, story_id)`, stores full `BuilderStoryDraft` as JSONB, RLS enabled
- `set_updated_at` trigger function auto-stamps `updated_at` on every mutation

### TypeScript layer (`src/lib/server/db/`)
| File | Purpose |
|---|---|
| `schema.ts` | `Database` type + `Row`/`Insert`/`Update` shapes for both tables |
| `supabase.ts` | Lazy service-role singleton; returns `null` when env vars absent |
| `sessionRepository.ts` | `upsertPlaySession`, `loadPlaySession`, `deletePlaySession`, `listPlaySessionsForUser` |
| `builderRepository.ts` | `saveBuilderDraftToDb`, `loadBuilderDraftFromDb`, `deleteBuilderDraft`, `listBuilderDraftsForUser` |

## Env vars needed (set in Vercel + local `.env`)
| Var | Purpose |
|---|---|
| `SUPABASE_URL` | Project URL |
| `SUPABASE_SERVICE_ROLE_KEY` | Service-role key (server only, never client) |

## Test plan
- [ ] App builds and runs without `SUPABASE_URL` set (all DB calls are silent no-ops)
- [ ] `npm install` succeeds with `@supabase/supabase-js ^2.49`
- [ ] After provisioning: run migration, set env vars, confirm `upsertPlaySession` writes a row
- [ ] Confirm `loadPlaySession` returns the saved state
- [ ] Confirm anon key cannot SELECT from either table (RLS deny-all)