### PR TITLE
Sprint 10: Share card and OG image endpoint

### DIFF
--- a/src/lib/components/ShareCard.svelte
+++ b/src/lib/components/ShareCard.svelte
@@ -1,0 +1,305 @@
+<!--
+  ShareCard — floating share panel for the story reader.
+
+  Props:
+    storyId   (required) — story identifier, used to build the canonical URL
+    title     (optional) — human-readable story title shown in the card and
+                           passed through to the OG image endpoint
+    sceneId   (optional) — current scene label forwarded to the OG image
+    beatCount (optional) — current beat count forwarded to the OG image
+    role      (optional) — player's infrastructure role (forwarded to OG)
+
+  Emits nothing (self-contained).
+
+  Usage:
+    <ShareCard storyId={data.storyId} title="No Vacancies" role={gameState.role} />
+-->
+<script lang="ts">
+	import { browser } from '$app/environment';
+
+	// ─── Props ─────────────────────────────────────────────────────────────────
+
+	export let storyId: string;
+	export let title = 'No Vacancies';
+	export let sceneId: string | null = null;
+	export let beatCount: number | null = null;
+	export let role: string | null = null;
+
+	// ─── State ─────────────────────────────────────────────────────────────────
+
+	let copied = false;
+	let open = false;
+	let copyTimeout: ReturnType<typeof setTimeout> | null = null;
+
+	// ─── Derived ───────────────────────────────────────────────────────────────
+
+	$: canonicalUrl = browser
+		? `${window.location.origin}/story/${encodeURIComponent(storyId)}`
+		: `/story/${encodeURIComponent(storyId)}`;
+
+	$: ogImageUrl = (() => {
+		const params = new URLSearchParams({ title });
+		if (sceneId) params.set('scene', sceneId);
+		if (role) params.set('role', role);
+		if (beatCount !== null) params.set('beat', String(beatCount));
+		return `/api/og?${params.toString()}`;
+	})();
+
+	// ─── Actions ───────────────────────────────────────────────────────────────
+
+	async function share() {
+		if (browser && navigator.share) {
+			try {
+				await navigator.share({
+					title,
+					text: 'I just became infrastructure. Play No Vacancies.',
+					url: canonicalUrl
+				});
+				return;
+			} catch {
+				// User cancelled or API unavailable — fall through to copy.
+			}
+		}
+		await copyToClipboard();
+	}
+
+	async function copyToClipboard() {
+		if (!browser) return;
+		try {
+			await navigator.clipboard.writeText(canonicalUrl);
+		} catch {
+			// Fallback for insecure contexts / older browsers.
+			const el = document.createElement('textarea');
+			el.value = canonicalUrl;
+			el.style.position = 'fixed';
+			el.style.opacity = '0';
+			document.body.appendChild(el);
+			el.select();
+			document.execCommand('copy');
+			document.body.removeChild(el);
+		}
+		copied = true;
+		if (copyTimeout) clearTimeout(copyTimeout);
+		copyTimeout = setTimeout(() => {
+			copied = false;
+		}, 2500);
+	}
+
+	function togglePanel() {
+		open = !open;
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') open = false;
+	}
+</script>
+
+<svelte:window on:keydown={handleKeydown} />
+
+<!-- Trigger button -->
+<button
+	class="share-trigger"
+	aria-label="Share this story"
+	aria-expanded={open}
+	on:click={togglePanel}
+>
+	<svg class="share-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+		<circle cx="18" cy="5" r="3" stroke="currentColor" stroke-width="2"/>
+		<circle cx="6" cy="12" r="3" stroke="currentColor" stroke-width="2"/>
+		<circle cx="18" cy="19" r="3" stroke="currentColor" stroke-width="2"/>
+		<line x1="8.59" y1="13.51" x2="15.42" y2="17.49" stroke="currentColor" stroke-width="2"/>
+		<line x1="15.41" y1="6.51" x2="8.59" y2="10.49" stroke="currentColor" stroke-width="2"/>
+	</svg>
+	Share
+</button>
+
+<!-- Dropdown panel -->
+{#if open}
+	<!-- svelte-ignore a11y-click-events-have-key-events -->
+	<!-- svelte-ignore a11y-no-static-element-interactions -->
+	<div class="backdrop" on:click={() => (open = false)} aria-hidden="true"/>
+
+	<div class="panel" role="dialog" aria-modal="true" aria-label="Share story">
+		<!-- OG image preview -->
+		<div class="preview-wrap">
+			<img
+				src={ogImageUrl}
+				alt="Story share preview"
+				class="preview-img"
+				width="1200"
+				height="630"
+				loading="lazy"
+			/>
+		</div>
+
+		<!-- URL field + copy -->
+		<div class="url-row">
+			<span class="url-text" title={canonicalUrl}>{canonicalUrl}</span>
+			<button class="copy-btn" on:click={copyToClipboard} aria-label="Copy link">
+				{#if copied}
+					<svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+						<polyline points="20 6 9 17 4 12" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+					</svg>
+					Copied!
+				{:else}
+					<svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+						<rect x="9" y="9" width="13" height="13" rx="2" stroke="currentColor" stroke-width="2"/>
+						<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" stroke="currentColor" stroke-width="2"/>
+					</svg>
+					Copy link
+				{/if}
+			</button>
+		</div>
+
+		<!-- Native share -->
+		{#if browser && 'share' in navigator}
+			<button class="native-share-btn" on:click={share}>
+				Share via…
+			</button>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	/* ── Trigger ──────────────────────────────────────────────────────────────── */
+
+	.share-trigger {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		padding: 0.45rem 1rem;
+		border: 1px solid var(--color-border, #2a4060);
+		border-radius: 6px;
+		background: transparent;
+		color: var(--color-muted, #94a3b8);
+		font-size: 0.875rem;
+		font-weight: 500;
+		cursor: pointer;
+		transition: color 0.15s, border-color 0.15s, background 0.15s;
+		position: relative;
+	}
+
+	.share-trigger:hover {
+		color: var(--color-text, #f1f5f9);
+		border-color: var(--color-accent, #f59e0b);
+		background: rgba(245, 158, 11, 0.06);
+	}
+
+	.share-icon {
+		width: 1rem;
+		height: 1rem;
+	}
+
+	/* ── Backdrop ─────────────────────────────────────────────────────────────── */
+
+	.backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: 40;
+		background: transparent;
+	}
+
+	/* ── Panel ────────────────────────────────────────────────────────────────── */
+
+	.panel {
+		position: absolute;
+		z-index: 50;
+		top: calc(100% + 8px);
+		right: 0;
+		width: clamp(300px, 90vw, 420px);
+		background: var(--color-surface, #0d1a2e);
+		border: 1px solid var(--color-border, #1e3a5f);
+		border-radius: 10px;
+		box-shadow:
+			0 4px 24px rgba(0, 0, 0, 0.6),
+			0 0 0 1px rgba(245, 158, 11, 0.08);
+		padding: 0.75rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.6rem;
+	}
+
+	/* ── Preview ──────────────────────────────────────────────────────────────── */
+
+	.preview-wrap {
+		border-radius: 6px;
+		overflow: hidden;
+		border: 1px solid var(--color-border, #1e3a5f);
+		background: #070c14;
+		aspect-ratio: 1200 / 630;
+	}
+
+	.preview-img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+	}
+
+	/* ── URL row ──────────────────────────────────────────────────────────────── */
+
+	.url-row {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		background: var(--color-inset, #070c14);
+		border: 1px solid var(--color-border, #1e3a5f);
+		border-radius: 6px;
+		padding: 0.4rem 0.5rem 0.4rem 0.75rem;
+	}
+
+	.url-text {
+		flex: 1;
+		font-family: 'Courier New', monospace;
+		font-size: 0.78rem;
+		color: var(--color-muted, #94a3b8);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.copy-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3rem;
+		flex-shrink: 0;
+		padding: 0.3rem 0.65rem;
+		border: 1px solid var(--color-accent, #f59e0b);
+		border-radius: 5px;
+		background: transparent;
+		color: var(--color-accent, #f59e0b);
+		font-size: 0.8rem;
+		font-weight: 600;
+		cursor: pointer;
+		transition: background 0.15s, color 0.15s;
+		white-space: nowrap;
+	}
+
+	.copy-btn:hover {
+		background: rgba(245, 158, 11, 0.12);
+	}
+
+	.copy-btn svg {
+		width: 0.9rem;
+		height: 0.9rem;
+	}
+
+	/* ── Native share ─────────────────────────────────────────────────────────── */
+
+	.native-share-btn {
+		width: 100%;
+		padding: 0.55rem;
+		border: 1px solid var(--color-border, #1e3a5f);
+		border-radius: 6px;
+		background: transparent;
+		color: var(--color-muted, #94a3b8);
+		font-size: 0.875rem;
+		cursor: pointer;
+		transition: color 0.15s, border-color 0.15s;
+	}
+
+	.native-share-btn:hover {
+		color: var(--color-text, #f1f5f9);
+		border-color: var(--color-muted, #64748b);
+	}
+</style>

--- a/src/routes/api/og/+server.ts
+++ b/src/routes/api/og/+server.ts
@@ -1,0 +1,185 @@
+/**
+ * Dynamic Open Graph image endpoint.
+ *
+ * Returns a 1200×630 SVG sized for OG/Twitter card previews.
+ *
+ * Usage in <svelte:head>:
+ *   <meta property="og:image" content="/api/og?title=...&scene=...&role=..." />
+ *
+ * Query params (all optional, all sanitised against XSS):
+ *   title  — story title shown large (default "No Vacancies")
+ *   scene  — current scene / chapter label
+ *   role   — player job title / infrastructure role
+ *   beat   — numeric beat count shown as a progress hint
+ */
+import type { RequestHandler } from '@sveltejs/kit';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Escape the five unsafe XML characters. */
+function escapeXml(str: string): string {
+	return str
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&apos;');
+}
+
+/**
+ * Naive word-wrap: split `text` into lines no longer than `maxChars`.
+ * Returns at most `maxLines` lines; excess content is silently dropped.
+ */
+function wrapText(text: string, maxChars: number, maxLines: number): string[] {
+	const words = text.split(/\s+/);
+	const lines: string[] = [];
+	let current = '';
+
+	for (const word of words) {
+		const candidate = current ? `${current} ${word}` : word;
+		if (candidate.length <= maxChars) {
+			current = candidate;
+		} else {
+			if (current) lines.push(current);
+			if (lines.length >= maxLines) break;
+			// Truncate a single word that's longer than maxChars
+			current = word.length > maxChars ? word.slice(0, maxChars - 1) + '…' : word;
+		}
+	}
+	if (current && lines.length < maxLines) lines.push(current);
+
+	return lines;
+}
+
+// ─── SVG generation ───────────────────────────────────────────────────────────
+
+interface OgParams {
+	title: string;
+	scene: string | null;
+	role: string | null;
+	beat: number | null;
+}
+
+function buildSvg({ title, scene, role, beat }: OgParams): string {
+	const safeTitle = escapeXml(title);
+	const safeScene = scene ? escapeXml(scene) : null;
+	const safeRole = role ? escapeXml(role) : null;
+
+	const titleLines = wrapText(safeTitle, 32, 3);
+	const titleFontSize = titleLines.length > 1 ? 72 : 84;
+	const titleLineHeight = titleFontSize * 1.15;
+	const titleStartY = 260 - ((titleLines.length - 1) * titleLineHeight) / 2;
+
+	// Bottom-row metadata pills
+	const pills: string[] = [];
+	if (safeScene) pills.push(`Scene: ${safeScene}`);
+	if (safeRole) pills.push(safeRole);
+	if (beat !== null) pills.push(`Beat ${beat}`);
+
+	const pillSvg = pills
+		.map((text, i) => {
+			const x = 80 + i * 260;
+			return `
+    <rect x="${x}" y="536" width="240" height="42" rx="6" fill="#1e2d3d" stroke="#2a4060" stroke-width="1"/>
+    <text x="${x + 120}" y="563" font-family="system-ui,sans-serif" font-size="20"
+          fill="#94a3b8" text-anchor="middle">${escapeXml(text)}</text>`;
+		})
+		.join('');
+
+	return `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#070c14"/>
+      <stop offset="100%" stop-color="#0d1a2e"/>
+    </linearGradient>
+    <!-- Neon glow filter for the sign text -->
+    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <!-- Subtle drop shadow for title text -->
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="2" stdDeviation="6" flood-color="#000" flood-opacity="0.6"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bg)"/>
+
+  <!-- Subtle dot-grid texture -->
+  <pattern id="dots" x="0" y="0" width="30" height="30" patternUnits="userSpaceOnUse">
+    <circle cx="1" cy="1" r="1" fill="#ffffff06"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#dots)"/>
+
+  <!-- Top border accent -->
+  <rect x="0" y="0" width="1200" height="4" fill="#f59e0b" opacity="0.8"/>
+
+  <!-- "NO VACANCIES" motel-sign header -->
+  <rect x="80" y="42" width="460" height="64" rx="6"
+        fill="#0a0d14" stroke="#f59e0b" stroke-width="1.5" opacity="0.9"/>
+  <text x="310" y="88"
+        font-family="'Courier New',Courier,monospace"
+        font-size="30" font-weight="700" letter-spacing="6"
+        fill="#f59e0b" text-anchor="middle" filter="url(#glow)">NO VACANCIES</text>
+
+  <!-- Blinking dot accent (static in SVG, but evocative) -->
+  <circle cx="570" cy="74" r="6" fill="#ef4444" opacity="0.9"/>
+
+  <!-- Story title lines -->
+${titleLines
+	.map(
+		(line, i) => `  <text x="600" y="${Math.round(titleStartY + i * titleLineHeight)}"
+        font-family="system-ui,-apple-system,'Segoe UI',sans-serif"
+        font-size="${titleFontSize}" font-weight="700"
+        fill="#f1f5f9" text-anchor="middle" filter="url(#shadow)">${line}</text>`
+	)
+	.join('\n')}
+
+  <!-- Horizontal rule -->
+  <line x1="80" y1="490" x2="1120" y2="490" stroke="#1e3a5f" stroke-width="1"/>
+
+  <!-- Metadata pills -->
+${pillSvg}
+
+  <!-- Branding — bottom right -->
+  <text x="1120" y="590"
+        font-family="system-ui,sans-serif" font-size="22" font-weight="600"
+        fill="#f59e0b" text-anchor="end" opacity="0.7">no-vacancies.vercel.app</text>
+
+  <!-- Bottom border accent -->
+  <rect x="0" y="626" width="1200" height="4" fill="#f59e0b" opacity="0.4"/>
+</svg>`;
+}
+
+// ─── Handler ──────────────────────────────────────────────────────────────────
+
+export const GET: RequestHandler = ({ url }) => {
+	const raw = {
+		title: url.searchParams.get('title')?.slice(0, 120) || 'No Vacancies',
+		scene: url.searchParams.get('scene')?.slice(0, 80) ?? null,
+		role: url.searchParams.get('role')?.slice(0, 60) ?? null,
+		beatRaw: url.searchParams.get('beat')
+	};
+
+	const beat = raw.beatRaw ? parseInt(raw.beatRaw, 10) : null;
+
+	const svg = buildSvg({
+		title: raw.title,
+		scene: raw.scene,
+		role: raw.role,
+		beat: Number.isFinite(beat) ? beat : null
+	});
+
+	return new Response(svg, {
+		headers: {
+			'Content-Type': 'image/svg+xml',
+			'Cache-Control': 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800',
+			'X-Content-Type-Options': 'nosniff'
+		}
+	});
+};


### PR DESCRIPTION
## Summary

Final sprint: adds dynamic Open Graph image generation and a reusable share card component.

### New files
| File | Purpose |
|---|---|
| `src/routes/api/og/+server.ts` | `GET /api/og` — returns 1200×630 SVG for `og:image`. Accepts `title`, `scene`, `role`, `beat` query params. No extra deps. |
| `src/lib/components/ShareCard.svelte` | Drop-in share panel. Shows OG preview thumbnail, URL copy button, and native share sheet on mobile. |

### OG image design
- Dark atmospheric background (`#070c14` → `#0d1a2e` gradient)
- Amber `NO VACANCIES` neon-sign header with SVG glow filter
- Auto word-wrapped title (up to 3 lines, font scales with line count)
- Optional metadata pills: scene, role, beat count
- `Cache-Control: public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800`

### ShareCard props
| Prop | Type | Description |
|---|---|---|
| `storyId` | `string` | Used to build canonical URL |
| `title` | `string` | Forwarded to OG endpoint |
| `sceneId` | `string \| null` | Current scene name |
| `beatCount` | `number \| null` | Progress hint |
| `role` | `string \| null` | Player's infrastructure role |

### Wiring (one-liner, add to story page)
```svelte
<svelte:head>
  <meta property="og:image" content="/api/og?title={encodeURIComponent(title)}" />
</svelte:head>
<ShareCard storyId={data.storyId} {title} role={gameState.role} />
```

## Test plan
- [ ] `GET /api/og?title=You+Are+The+Motel+Wi-Fi` returns an SVG with the title visible
- [ ] Long titles wrap to at most 3 lines without escaping the canvas
- [ ] `<script>` in title query param is XML-escaped (no XSS)
- [ ] Share button copies URL to clipboard on desktop
- [ ] Share button triggers native share sheet on Android/iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)