### PR TITLE
fix(sprint-12): AI prompt wiring, forbidden language, builder prompt cleanup

### DIFF
--- a/ai_builder_prompt.md
+++ b/ai_builder_prompt.md
@@ -76,7 +76,7 @@ export function createGameState() {
         storyThreads: {
             oswaldoConflict: 0,
             trinaTension: 0,
-            marcusDependency: 0
+            oswaldoDependency: 0
         },
         inventory: [],
         unlockedEndings: []

--- a/src/lib/stories/no-vacancies/index.ts
+++ b/src/lib/stories/no-vacancies/index.ts
@@ -14,6 +14,7 @@ import {
 	SYSTEM_PROMPT,
 	VOICE_CEILING_LINES
 } from '$lib/stories/no-vacancies/prompts';
+import { BEHAVIOR_SEEDS, COMBO_STATE_LINES } from '$lib/stories/no-vacancies/voice';
 
 const imagePaths: Record<string, string> = {
 	[ImageKeys.HOTEL_ROOM]: '/images/hotel_room.png',
@@ -192,28 +193,8 @@ export const noVacanciesCartridge: StoryDefinition = {
 		aestheticStatement:
 			'Motive-driven anthropomorphism. Make every line behave. Give objects, rooms, and silence motives. Nothing explains itself.',
 		voiceCeilingLines: VOICE_CEILING_LINES,
-		behaviorSeeds: [
-			{
-				incident:
-					'Rides five miles for Dex\'s smokes, then asks Sydney to DoorDash him water because he is "too sore" to walk to the machine.',
-				pattern: 'Selectively allocates effort based on who validates him, not who needs him.'
-			},
-			{
-				incident:
-					'Dex listens like a friend, then her private complaint comes back from somebody else with different punctuation.',
-				pattern: 'Concern is the entry fee; betrayal is the operating model.'
-			}
-		],
-		comboStateLines: [
-			{
-				when: 'When exhaustion is high and the room is still unpaid',
-				line: 'She is too tired to be diplomatic and too broke to be gentle.'
-			},
-			{
-				when: 'When Oswaldo conflict is high and awareness is still low',
-				line: 'He feels accused before he feels responsible.'
-			}
-		]
+		behaviorSeeds: BEHAVIOR_SEEDS.map((seed) => ({ ...seed })),
+		comboStateLines: COMBO_STATE_LINES.map((entry) => ({ ...entry }))
 	},
 	builder: {
 		referencePromptGuide:

--- a/src/lib/stories/no-vacancies/prompts.ts
+++ b/src/lib/stories/no-vacancies/prompts.ts
@@ -1,6 +1,10 @@
 import { EndingTypes, ImageKeys, type NarrativeContext } from '$lib/contracts';
 import { lessons } from '$lib/narrative/lessonsCatalog';
 import { formatLessonsForPrompt, formatNarrativeContextSection } from '$lib/narrative/promptFormatting';
+import {
+	formatBehaviorSeedsForPrompt,
+	formatComboStateLinesForPrompt
+} from '$lib/stories/no-vacancies/voice';
 
 export const VOICE_CEILING_LINES = Object.freeze([
 	'He will ride five miles for strangers and five inches for nobody in this room.',
@@ -242,12 +246,10 @@ Sydney doesn't just "pay bills." She manages:
 ${VOICE_CEILING_LINES.map((line) => `- "${line}"`).join('\n')}
 
 ## BEHAVIOR SEEDS (enacted patterns — surface through incident; do not state the pattern directly)
-- Oswaldo: Rides five miles for Dex's smokes, then asks Sydney to DoorDash him water because he is "too sore" to walk to the machine. → Selectively allocates effort based on who validates him, not who needs him.
-- Dex: Listens like a friend, then her private complaint comes back from somebody else with different punctuation. → Concern is the entry fee; betrayal is the operating model.
+${formatBehaviorSeedsForPrompt()}
 
 ## COMBO STATE LINES (use when state conditions are met — do not force)
-- When exhaustion is high and the room is still unpaid: "She is too tired to be diplomatic and too broke to be gentle."
-- When Oswaldo conflict is high and awareness is still low: "He feels accused before he feels responsible."
+${formatComboStateLinesForPrompt()}
 
 ## 17 LESSONS TO WEAVE IN
 Work them in naturally through situation, never lecture:

--- a/src/lib/stories/no-vacancies/voice.ts
+++ b/src/lib/stories/no-vacancies/voice.ts
@@ -1,0 +1,49 @@
+/**
+ * No Vacancies - Voice Reference Constants
+ *
+ * Single source of truth for behavioral guardrails that must reach the runtime
+ * AI prompt AND the builder cartridge. Previously `behaviorSeeds` and
+ * `comboStateLines` were defined only on the cartridge (index.ts) and a
+ * duplicate copy was hardcoded into the SYSTEM_PROMPT, so cartridge updates
+ * never reached Grok. Both consumers now import from here.
+ */
+
+import type { BehaviorSeed, ComboStateLine } from '$lib/stories/types';
+
+export type { BehaviorSeed, ComboStateLine };
+
+export const BEHAVIOR_SEEDS: readonly BehaviorSeed[] = Object.freeze([
+	{
+		incident:
+			"Rides five miles for Dex's smokes, then asks Sydney to DoorDash him water because he is \"too sore\" to walk to the machine.",
+		pattern: 'Selectively allocates effort based on who validates him, not who needs him.'
+	},
+	{
+		incident:
+			'Dex listens like a friend, then her private complaint comes back from somebody else with different punctuation.',
+		pattern: 'Concern is the entry fee; betrayal is the operating model.'
+	}
+]);
+
+export const COMBO_STATE_LINES: readonly ComboStateLine[] = Object.freeze([
+	{
+		when: 'When exhaustion is high and the room is still unpaid',
+		line: 'She is too tired to be diplomatic and too broke to be gentle.'
+	},
+	{
+		when: 'When Oswaldo conflict is high and awareness is still low',
+		line: 'He feels accused before he feels responsible.'
+	}
+]);
+
+export function formatBehaviorSeedsForPrompt(seeds: readonly BehaviorSeed[] = BEHAVIOR_SEEDS): string {
+	return seeds
+		.map((seed) => `- ${seed.incident} → ${seed.pattern}`)
+		.join('\n');
+}
+
+export function formatComboStateLinesForPrompt(lines: readonly ComboStateLine[] = COMBO_STATE_LINES): string {
+	return lines
+		.map((entry) => `- ${entry.when}: "${entry.line}"`)
+		.join('\n');
+}


### PR DESCRIPTION
## Audit Summary (4 bugs checked against `main`)

| # | Bug | Status | Files touched |
|---|-----|--------|--------------|
| 1 | `behaviorSeeds` + `comboStateLines` dead code in runtime AI prompt | **FOUND — fixed** | `voice.ts` (new), `prompts.ts`, `index.ts` |
| 2 | `emotionalStakes` uses forbidden language ("Realizing...", "Feeling...", "Wondering...") | **NOT PRESENT** — see notes | none |
| 3 | Builder AI prompts still say "MARCUS" | **FOUND — fixed** | `ai_builder_prompt.md` |
| 4 | `package.json` name is `"sydney-story"` | **ALREADY FIXED on main** (`"name": "no-vacancies"`) | none |

## Bug 1 — runtime prompt wiring

`src/lib/stories/no-vacancies/index.ts` exported `voice.behaviorSeeds` and `voice.comboStateLines` arrays on the `noVacanciesCartridge`. `behaviorSeeds` reaches the AI through one path only — `draftGenerator.ts` (the *builder* prompt). The *runtime* `SYSTEM_PROMPT` in `src/lib/stories/no-vacancies/prompts.ts` was carrying a hardcoded duplicate copy of the same content under `## BEHAVIOR SEEDS` and `## COMBO STATE LINES`, with no reference back to the cartridge arrays. Updating the cartridge had zero effect on what Grok actually sees during play.

**Fix:** new module `src/lib/stories/no-vacancies/voice.ts` holds the canonical `BEHAVIOR_SEEDS` / `COMBO_STATE_LINES` arrays plus `formatBehaviorSeedsForPrompt()` / `formatComboStateLinesForPrompt()` helpers. `prompts.ts` now interpolates the formatted strings into `SYSTEM_PROMPT` so cartridge edits flow straight into the runtime prompt. `index.ts` re-exports the same constants onto `cartridge.voice` so the builder keeps working with no behaviour change. Single source of truth, no duplication.

## Bug 2 — emotionalStakes

Checked every `emotionalStakes: [...]` entry in `src/lib/narrative/lessonsCatalog.ts` (27 lessons). None of them begin with the forbidden gerunds ("Realizing...", "Feeling...", "Wondering..."). They lean on noun phrases ("The exhaustion of...", "The trap of...", "The terror of...") which is fine.

Additional finding worth flagging: `emotionalStakes` is **never** sent to the AI at all. `formatLessonsForPrompt()` in `src/lib/narrative/promptFormatting.ts` only serialises `title`, `quote`, `insight`, the first two `storyTriggers`, and `unconventionalAngle`. So even if forbidden phrasing existed there, Grok would not see it. No code change required for this bug.

## Bug 3 — MARCUS in builder prompt

`ai_builder_prompt.md` line 79 still had `marcusDependency: 0` inside the example `storyThreads` object. Renamed to `oswaldoDependency: 0`.

Other occurrences of "Marcus" in the repo (`CHANGELOG.md`, `AI_LESSONS_LEARNED.md`, `claude.md`) are historical notes documenting the rename — left unchanged on purpose. `ai_builder_prompt_narrative.md` does not mention Marcus.

## Bug 4 — package.json

Already correct on `main`: `"name": "no-vacancies"`. No change.

## Files in this PR

- `src/lib/stories/no-vacancies/voice.ts` — new
- `src/lib/stories/no-vacancies/prompts.ts` — import voice helpers, replace hardcoded BEHAVIOR SEEDS / COMBO STATE LINES blocks with interpolated formatters
- `src/lib/stories/no-vacancies/index.ts` — import canonical constants, replace inline literals with `BEHAVIOR_SEEDS.map(...)` / `COMBO_STATE_LINES.map(...)` so the cartridge keeps mutable arrays
- `ai_builder_prompt.md` — `marcusDependency` → `oswaldoDependency`

## Test plan

- [ ] `npm run check` — TypeScript types resolve across the new `voice.ts` module (imports from `$lib/stories/types`, no circular import with `prompts.ts` or `index.ts`)
- [ ] `npm run lint` — passes
- [ ] `npm run test` — narrative + provider marker tests still green
- [ ] Inspect the rendered `SYSTEM_PROMPT` at runtime (or via the narrative test snapshot) and confirm the `## BEHAVIOR SEEDS` / `## COMBO STATE LINES` sections are populated from the cartridge constants
- [ ] Confirm builder draft generation (`draftGenerator.ts`) still receives `noVacanciesCartridge.voice.behaviorSeeds` populated