### PR TITLE
fix(sprint-12): generate userId server-side, harden session cookie verification

### DIFF
--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -92,7 +92,9 @@ function constantTimeEquals(a: string, b: string): boolean {
 function isValidSessionEnvelope(payload: SessionEnvelope, nowSeconds: number): payload is Required<SessionEnvelope> {
 	return (
 		typeof payload.userId === 'string' &&
+		payload.userId.length > 0 &&
 		typeof payload.role === 'string' &&
+		payload.role.length > 0 &&
 		typeof payload.iat === 'number' &&
 		typeof payload.exp === 'number' &&
 		payload.iat > 0 &&
@@ -117,12 +119,29 @@ export async function createSignedSessionCookieValue(
 	return `${encodedPayload}.${signature}`;
 }
 
+/**
+ * Parse and verify a signed session cookie.
+ *
+ * SECURITY: A non-null return value is the ONLY trustworthy signal that a request
+ * carries a valid, server-issued identity. The HMAC-SHA256 signature is verified
+ * against the configured `AUTH_SESSION_SECRET` using a constant-time comparison
+ * before any field of the payload is consumed. If the secret is unset, every
+ * cookie is treated as unauthenticated — we never accept an unverified envelope.
+ *
+ * Callers (e.g. `getSessionUser` and the `builderAuth` middleware) must treat a
+ * `null` return as "no authenticated session" and refuse to fall back to any
+ * client-supplied identity hint (headers, body fields, query params, etc.).
+ */
 export async function parseSessionCookie(
 	rawCookie: string | undefined,
 	secret: string | undefined
 ): Promise<SessionUser | null> {
 	if (!rawCookie || !secret) return null;
-	const [encodedPayload, signature] = rawCookie.split('.');
+	// A well-formed cookie has exactly two `.`-separated segments: payload.signature.
+	// Reject anything else outright to keep the verification path unambiguous.
+	const segments = rawCookie.split('.');
+	if (segments.length !== 2) return null;
+	const [encodedPayload, signature] = segments;
 	if (!encodedPayload || !signature) return null;
 
 	try {
@@ -168,6 +187,13 @@ export function getAuthSessionSecret(): string | undefined {
 	return runtimeProcess.process?.env?.AUTH_SESSION_SECRET;
 }
 
+/**
+ * Resolve the authenticated session user for the current request, if any.
+ *
+ * This is the single entry point protected routes should use to learn who the
+ * caller is. It delegates to `parseSessionCookie`, which enforces HMAC signature
+ * verification, so any non-null result is a server-issued identity.
+ */
 export async function getSessionUser(event: RequestEvent): Promise<SessionUser | null> {
 	return parseSessionCookie(event.cookies.get(SESSION_COOKIE_NAME), getAuthSessionSecret());
 }

--- a/src/routes/api/auth/login/+server.ts
+++ b/src/routes/api/auth/login/+server.ts
@@ -11,6 +11,20 @@ import {
 	isDemoAuthEnabled
 } from '$lib/server/auth';
 
+/**
+ * Demo login endpoint.
+ *
+ * SECURITY: This endpoint MUST NOT trust any identity supplied by the client. The
+ * server is the sole source of truth for `userId` — even in demo mode. A previous
+ * iteration of this handler accepted a `userId` from the request body and embedded
+ * it directly into the signed session cookie, which allowed any client to claim any
+ * identity (including impersonating other demo users) by simply changing the body
+ * payload. We now ignore any caller-supplied `userId` entirely and mint a fresh
+ * server-generated identifier via `crypto.randomUUID()`.
+ *
+ * The endpoint is additionally gated behind `DEMO_AUTH_ENABLED=1`, so in production
+ * (where that flag is unset) the route returns 403 before reading the body at all.
+ */
 export const POST: RequestHandler = async ({ request, cookies, url }) => {
 	if (!isDemoAuthEnabled()) {
 		return json(
@@ -24,17 +38,13 @@ export const POST: RequestHandler = async ({ request, cookies, url }) => {
 		);
 	}
 
+	// Only `role` is read from the body. Any client-supplied `userId` is intentionally
+	// ignored — see the SECURITY note above.
 	const payload = (await request.json().catch(() => ({}))) as {
-		userId?: string;
 		role?: string;
 	};
 
-	const userId = typeof payload.userId === 'string' ? payload.userId.trim() : '';
 	const role = typeof payload.role === 'string' ? payload.role.trim() : '';
-
-	if (!userId) {
-		return json({ error: { code: 'invalid_user', message: 'userId is required.' } }, { status: 400 });
-	}
 
 	if (!isBuilderRole(role)) {
 		return json(
@@ -55,6 +65,9 @@ export const POST: RequestHandler = async ({ request, cookies, url }) => {
 			{ status: 503 }
 		);
 	}
+
+	// Server-side identity generation. Never derive userId from caller input.
+	const userId = crypto.randomUUID();
 
 	const value = await createSignedSessionCookieValue({ userId, role }, secret);
 	cookies.set(SESSION_COOKIE_NAME, value, {


### PR DESCRIPTION
## Summary

PR #76 introduced demo auth login/logout routes. The login route accepts a caller-supplied `userId` from the request body and embeds it directly into the signed session cookie. This makes identity forgeable: any client can claim to be any user by sending `{"userId": "victim", "role": "author"}`.

This PR removes that trust boundary and tightens the surrounding session machinery.

## What was vulnerable

**`src/routes/api/auth/login/+server.ts` (before):**

```ts
const payload = (await request.json().catch(() => ({}))) as {
    userId?: string;
    role?: string;
};
const userId = typeof payload.userId === 'string' ? payload.userId.trim() : '';
// ...
const value = await createSignedSessionCookieValue({ userId, role }, secret);
```

The HMAC signature over the envelope was real, but the envelope's `userId` came straight from the request body. The signature only proves "this server signed *some* user's claim," not "this is who the user actually is." Any client could mint a valid signed cookie for any identity.

While the route is gated behind `DEMO_AUTH_ENABLED=1` (so production isn't directly exposed), demo environments are still shared and the previous behaviour let any visitor impersonate any other demo user.

## What changed

### 1. `src/routes/api/auth/login/+server.ts`
- Removed `userId` from the accepted body schema entirely.
- Server now mints identity via `crypto.randomUUID()`. The client cannot influence `userId` under any circumstance.
- `role` is still read from the body (it's a demo role chooser) but continues to be validated against `BUILDER_ROLES` via `isBuilderRole`.
- Added a `SECURITY` comment at the top of the handler describing the trust boundary so future contributors don't reintroduce the same pattern.

### 2. `src/lib/server/auth.ts`
Defensive clarifications around the verification path. The HMAC verification was already correct (constant-time compare in `parseSessionCookie`, invoked by `getSessionUser`, which is the only identity source for the `builderAuth` middleware that guards `/builder` and `/api/builder/*`). Changes:
- `parseSessionCookie` now requires the cookie to have **exactly** two `.`-separated segments. Previously `split('.').slice(0, 2)` semantics would silently ignore extra segments; rejecting outright keeps the verification surface unambiguous.
- `isValidSessionEnvelope` now rejects empty-string `userId` / `role` (belt-and-braces alongside the login route's validation).
- Added doc comments to `parseSessionCookie` and `getSessionUser` documenting the contract: a non-null return is the only trustworthy signal of an authenticated session, and callers must not fall back to client-supplied identity hints.

### Not changed
- `src/routes/api/auth/logout/+server.ts` is unaffected — it only deletes the cookie.
- `src/hooks.server.ts` already wires `builderAuth` into the request pipeline; signature verification on protected routes was confirmed to be enforced (`getSessionUser` -> `parseSessionCookie` -> HMAC verify) and required no changes.

## Verification audit

| Route | Verification path |
| --- | --- |
| `/builder/*` | `hooks.server.ts` -> `builderAuth` middleware -> `getSessionUser` -> `parseSessionCookie` (HMAC verify) |
| `/api/builder/*` | same as above |
| `/api/auth/login` | demo-only (`DEMO_AUTH_ENABLED=1`), now mints userId server-side |
| `/api/auth/logout` | no identity needed; just clears the cookie |

## Test plan
- [ ] With `DEMO_AUTH_ENABLED=1`, POST to `/api/auth/login` with `{"role":"author"}` and verify the response `user.userId` is a fresh UUID each call.
- [ ] POST to `/api/auth/login` with `{"userId":"attacker","role":"author"}` and verify the response `userId` is NOT `"attacker"` (it should be a server-generated UUID).
- [ ] With `DEMO_AUTH_ENABLED` unset, POST to `/api/auth/login` returns 403 `demo_auth_disabled`.
- [ ] Tamper with the session cookie (flip a byte in the signature segment) and verify `/api/builder/*` returns 401 `auth_required`.
- [ ] Truncate the session cookie to a single segment and verify the same 401 response (covers the `segments.length !== 2` guard).
- [ ] Logout flow still clears the cookie and redirects to `/login`.