### PR TITLE
feat(sprint-14): lesson alignment score for builder

### DIFF
--- a/src/lib/components/builder/AlignmentScore.svelte
+++ b/src/lib/components/builder/AlignmentScore.svelte
@@ -1,0 +1,384 @@
+<script lang="ts" context="module">
+	export interface AlignmentGap {
+		field: string;
+		issue: string;
+		suggestion: string;
+	}
+
+	export interface AlignmentResult {
+		score: number;
+		summary: string;
+		gaps: AlignmentGap[];
+	}
+
+	export interface AlignmentResponsePayload {
+		alignment: AlignmentResult;
+		lesson: { id: number; title: string };
+		source: 'ai' | 'fallback';
+	}
+</script>
+
+<script lang="ts">
+	import type { BuilderStoryDraft } from '$lib/stories/types';
+
+	export let draft: BuilderStoryDraft;
+	export let lessonId: string = '';
+	export let title: string = 'Lesson alignment';
+
+	type ViewState = 'idle' | 'loading' | 'ready' | 'error';
+
+	let viewState: ViewState = 'idle';
+	let errorMessage = '';
+	let result: AlignmentResult | null = null;
+	let resolvedLessonTitle: string | null = null;
+	let resultSource: 'ai' | 'fallback' | null = null;
+
+	$: hasLesson = typeof lessonId === 'string' && lessonId.trim().length > 0;
+	$: scoreTone = result ? toneForScore(result.score) : 'neutral';
+	$: meterPercent = result ? Math.max(0, Math.min(100, (result.score / 10) * 100)) : 0;
+
+	function toneForScore(score: number): 'low' | 'mid' | 'high' {
+		if (score <= 4) return 'low';
+		if (score <= 7) return 'mid';
+		return 'high';
+	}
+
+	async function runAlignmentCheck(): Promise<void> {
+		if (!hasLesson) {
+			viewState = 'error';
+			errorMessage = 'Select a lesson before checking alignment.';
+			return;
+		}
+		viewState = 'loading';
+		errorMessage = '';
+		try {
+			const response = await fetch('/api/builder/alignment', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ draft, lessonId })
+			});
+			const payload = (await response.json().catch(() => ({}))) as Partial<
+				AlignmentResponsePayload & { error: string }
+			>;
+			if (!response.ok || !payload.alignment) {
+				throw new Error(payload.error || `Alignment check failed (${response.status}).`);
+			}
+			result = payload.alignment;
+			resolvedLessonTitle = payload.lesson?.title ?? null;
+			resultSource = payload.source ?? null;
+			viewState = 'ready';
+		} catch (error) {
+			viewState = 'error';
+			errorMessage =
+				error instanceof Error ? error.message : 'Alignment check failed unexpectedly.';
+		}
+	}
+</script>
+
+<section class="alignment-score" aria-label={title}>
+	<header class="alignment-head">
+		<div>
+			<p class="alignment-kicker">Authoring signal</p>
+			<h3>{title}</h3>
+		</div>
+		<button
+			type="button"
+			class="alignment-button"
+			on:click={runAlignmentCheck}
+			disabled={viewState === 'loading' || !hasLesson}
+			data-testid="alignment-check"
+		>
+			{viewState === 'loading' ? 'Checking…' : result ? 'Re-check' : 'Check alignment'}
+		</button>
+	</header>
+
+	{#if !hasLesson}
+		<p class="alignment-empty">
+			Pick a lesson above to score how well this draft puts that lesson under pressure.
+		</p>
+	{:else if viewState === 'idle'}
+		<p class="alignment-empty">
+			Run a check to score how well the current draft surfaces the selected lesson.
+		</p>
+	{:else if viewState === 'loading'}
+		<p class="alignment-empty" aria-live="polite">Grading draft against lesson…</p>
+	{:else if viewState === 'error'}
+		<p class="alignment-error" role="alert">{errorMessage}</p>
+	{:else if viewState === 'ready' && result}
+		<div class="alignment-result">
+			<div class="alignment-meta">
+				{#if resolvedLessonTitle}
+					<p class="alignment-lesson">Lesson: <strong>{resolvedLessonTitle}</strong></p>
+				{/if}
+				{#if resultSource}
+					<p class="alignment-source">
+						Source: {resultSource === 'ai' ? 'Grok evaluator' : 'Heuristic fallback'}
+					</p>
+				{/if}
+			</div>
+
+			<div
+				class="alignment-meter"
+				class:is-low={scoreTone === 'low'}
+				class:is-mid={scoreTone === 'mid'}
+				class:is-high={scoreTone === 'high'}
+				role="img"
+				aria-label="Alignment score {result.score} of 10"
+			>
+				<div class="alignment-meter-track">
+					<div class="alignment-meter-fill" style="width: {meterPercent}%"></div>
+				</div>
+				<div class="alignment-meter-readout">
+					<span class="alignment-score-number">{result.score}</span>
+					<span class="alignment-score-suffix">/ 10</span>
+				</div>
+			</div>
+
+			<p class="alignment-summary">{result.summary}</p>
+
+			{#if result.gaps.length === 0}
+				<p class="alignment-empty">No gaps flagged. The draft is invoking the lesson cleanly.</p>
+			{:else}
+				<ul class="alignment-gaps">
+					{#each result.gaps as gap, index (index)}
+						<li class="alignment-gap">
+							<p class="alignment-gap-field"><code>{gap.field}</code></p>
+							<p class="alignment-gap-issue">{gap.issue}</p>
+							<p class="alignment-gap-suggestion">
+								<span class="alignment-gap-suggestion-label">Fix:</span>
+								{gap.suggestion}
+							</p>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
+	{/if}
+</section>
+
+<style>
+	.alignment-score {
+		--align-accent: var(--accent-bright, #6366f1);
+		--align-low: var(--amber-400, #f59e0b);
+		--align-mid: var(--amber-400, #f59e0b);
+		--align-high: var(--sage-400, #22c55e);
+		--align-card-bg: rgba(18, 12, 9, 0.92);
+		--align-card-border: var(--line-soft, rgba(247, 241, 232, 0.12));
+		--align-card-border-strong: var(--line-strong, rgba(247, 241, 232, 0.22));
+		--align-text: var(--text-100, #f7f1e8);
+		--align-text-dim: var(--text-300, #b8aa9d);
+		display: grid;
+		gap: 0.85rem;
+		padding: 1rem;
+		border: 1px solid var(--align-card-border);
+		border-radius: 16px;
+		background: linear-gradient(180deg, rgba(18, 12, 9, 0.92), rgba(10, 8, 7, 0.96));
+		box-shadow: var(--shadow-md, 0 16px 36px rgba(0, 0, 0, 0.22));
+		color: var(--align-text);
+	}
+
+	.alignment-head {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 0.75rem;
+	}
+
+	.alignment-head h3 {
+		margin: 0.1rem 0 0;
+		font-family: var(--font-display, serif);
+		font-size: 1.1rem;
+		color: var(--align-text);
+	}
+
+	.alignment-kicker {
+		margin: 0;
+		text-transform: uppercase;
+		letter-spacing: 0.14em;
+		font-size: 0.68rem;
+		color: var(--align-text-dim);
+	}
+
+	.alignment-button {
+		appearance: none;
+		border: 1px solid var(--align-card-border-strong);
+		background: rgba(247, 241, 232, 0.04);
+		color: var(--align-text);
+		font: inherit;
+		font-size: 0.82rem;
+		padding: 0.45rem 0.85rem;
+		border-radius: 8px;
+		cursor: pointer;
+		transition: background 120ms ease-out, border-color 120ms ease-out;
+	}
+
+	.alignment-button:hover:not(:disabled) {
+		background: rgba(247, 241, 232, 0.08);
+		border-color: var(--align-accent);
+	}
+
+	.alignment-button:disabled {
+		cursor: not-allowed;
+		opacity: 0.55;
+	}
+
+	.alignment-empty {
+		margin: 0;
+		padding: 0.85rem;
+		border: 1px dashed var(--align-card-border-strong);
+		border-radius: 12px;
+		color: var(--align-text-dim);
+		font-size: 0.88rem;
+	}
+
+	.alignment-error {
+		margin: 0;
+		padding: 0.85rem;
+		border: 1px solid var(--align-low);
+		border-radius: 12px;
+		color: var(--align-text);
+		background: rgba(245, 158, 11, 0.08);
+		font-size: 0.88rem;
+	}
+
+	.alignment-result {
+		display: grid;
+		gap: 0.85rem;
+	}
+
+	.alignment-meta {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
+		gap: 0.4rem;
+		font-size: 0.78rem;
+		color: var(--align-text-dim);
+	}
+
+	.alignment-meta p {
+		margin: 0;
+	}
+
+	.alignment-lesson strong {
+		color: var(--align-text);
+		font-weight: 600;
+	}
+
+	.alignment-meter {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		align-items: center;
+		gap: 0.85rem;
+	}
+
+	.alignment-meter-track {
+		height: 12px;
+		border-radius: 999px;
+		background: rgba(247, 241, 232, 0.08);
+		border: 1px solid var(--align-card-border-strong);
+		overflow: hidden;
+	}
+
+	.alignment-meter-fill {
+		height: 100%;
+		transition: width 240ms ease-out, background 240ms ease-out;
+		background: var(--align-mid);
+	}
+
+	.alignment-meter.is-low .alignment-meter-fill {
+		background: var(--align-low);
+	}
+
+	.alignment-meter.is-mid .alignment-meter-fill {
+		background: var(--align-mid);
+	}
+
+	.alignment-meter.is-high .alignment-meter-fill {
+		background: var(--align-high);
+	}
+
+	.alignment-meter-readout {
+		display: inline-flex;
+		align-items: baseline;
+		gap: 0.15rem;
+		font-family: var(--font-mono, monospace);
+		color: var(--align-text);
+	}
+
+	.alignment-meter.is-low .alignment-meter-readout {
+		color: var(--align-low);
+	}
+
+	.alignment-meter.is-high .alignment-meter-readout {
+		color: var(--align-high);
+	}
+
+	.alignment-score-number {
+		font-size: 1.55rem;
+		font-weight: 700;
+	}
+
+	.alignment-score-suffix {
+		font-size: 0.85rem;
+		color: var(--align-text-dim);
+	}
+
+	.alignment-summary {
+		margin: 0;
+		font-size: 0.92rem;
+		color: var(--align-text);
+		line-height: 1.4;
+	}
+
+	.alignment-gaps {
+		list-style: none;
+		display: grid;
+		gap: 0.6rem;
+		margin: 0;
+		padding: 0;
+	}
+
+	.alignment-gap {
+		display: grid;
+		gap: 0.25rem;
+		padding: 0.7rem 0.8rem;
+		border: 1px solid var(--align-card-border-strong);
+		border-left: 3px solid var(--align-low);
+		border-radius: 10px;
+		background: rgba(9, 7, 7, 0.55);
+	}
+
+	.alignment-gap p {
+		margin: 0;
+		font-size: 0.86rem;
+		line-height: 1.4;
+	}
+
+	.alignment-gap-field code {
+		font-family: var(--font-mono, monospace);
+		font-size: 0.78rem;
+		padding: 0.1rem 0.4rem;
+		border-radius: 6px;
+		background: rgba(247, 241, 232, 0.08);
+		color: var(--align-text);
+		letter-spacing: 0.02em;
+	}
+
+	.alignment-gap-issue {
+		color: var(--align-text);
+	}
+
+	.alignment-gap-suggestion {
+		color: var(--align-text-dim);
+	}
+
+	.alignment-gap-suggestion-label {
+		color: var(--align-high);
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		font-size: 0.7rem;
+		font-weight: 700;
+		margin-right: 0.3rem;
+	}
+</style>

--- a/src/routes/api/builder/alignment/+server.ts
+++ b/src/routes/api/builder/alignment/+server.ts
@@ -1,0 +1,302 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { callBuilderModel } from '$lib/server/ai/builder/modelClient';
+import { extractJsonObject } from '$lib/server/ai/builder/normalizers';
+import { getLessonById, type Lesson } from '$lib/narrative/lessonsCatalog';
+import { emitAiServerTelemetry } from '$lib/server/ai/telemetry';
+import type { BuilderStoryDraft } from '$lib/stories/types';
+
+export interface AlignmentGap {
+	field: string;
+	issue: string;
+	suggestion: string;
+}
+
+export interface AlignmentResult {
+	score: number;
+	summary: string;
+	gaps: AlignmentGap[];
+}
+
+export interface AlignmentResponse {
+	alignment: AlignmentResult;
+	lesson: { id: number; title: string };
+	source: 'ai' | 'fallback';
+}
+
+const KNOWN_FIELDS = new Set([
+	'title',
+	'premise',
+	'setting',
+	'aestheticStatement',
+	'voiceCeilingLines',
+	'characters',
+	'mechanics',
+	'openingPrompt',
+	'systemPrompt'
+]);
+
+function coerceLessonId(raw: unknown): number | null {
+	if (typeof raw === 'number' && Number.isFinite(raw)) return Math.trunc(raw);
+	if (typeof raw === 'string' && raw.trim()) {
+		const parsed = Number.parseInt(raw.trim(), 10);
+		if (Number.isFinite(parsed)) return parsed;
+	}
+	return null;
+}
+
+function clampScore(value: unknown): number {
+	if (typeof value !== 'number' || !Number.isFinite(value)) return 1;
+	return Math.max(1, Math.min(10, Math.round(value)));
+}
+
+function normalizeGaps(value: unknown): AlignmentGap[] {
+	if (!Array.isArray(value)) return [];
+	const out: AlignmentGap[] = [];
+	for (const raw of value) {
+		if (!raw || typeof raw !== 'object') continue;
+		const typed = raw as Partial<AlignmentGap>;
+		const field =
+			typeof typed.field === 'string' && typed.field.trim() ? typed.field.trim() : 'general';
+		const issue =
+			typeof typed.issue === 'string' && typed.issue.trim()
+				? typed.issue.trim()
+				: 'Unspecified gap.';
+		const suggestion =
+			typeof typed.suggestion === 'string' && typed.suggestion.trim()
+				? typed.suggestion.trim()
+				: 'Rewrite the field so it directly invokes the lesson.';
+		out.push({ field, issue, suggestion });
+	}
+	return out;
+}
+
+function normalizeAlignment(candidate: unknown): AlignmentResult {
+	if (!candidate || typeof candidate !== 'object') {
+		return {
+			score: 1,
+			summary: 'Evaluator returned an invalid payload.',
+			gaps: []
+		};
+	}
+	const typed = candidate as Partial<AlignmentResult>;
+	return {
+		score: clampScore(typed.score),
+		summary:
+			typeof typed.summary === 'string' && typed.summary.trim()
+				? typed.summary.trim()
+				: 'No summary returned.',
+		gaps: normalizeGaps(typed.gaps)
+	};
+}
+
+function summarizeDraft(draft: BuilderStoryDraft): string {
+	const characterSummary = (draft.characters ?? [])
+		.map((character, index) => {
+			const name = character?.name?.trim() || `Character ${index + 1}`;
+			const role = character?.role?.trim() || 'role';
+			const description = character?.description?.trim() || '(no description)';
+			return `- ${name} (${role}): ${description}`;
+		})
+		.join('\n');
+
+	const mechanicSummary = (draft.mechanics ?? [])
+		.map((mechanic, index) => {
+			const key = mechanic?.key?.trim() || `mechanic_${index + 1}`;
+			const label = mechanic?.label?.trim() || 'unlabeled';
+			const voiceLines = (mechanic?.voiceMap ?? [])
+				.map((entry) => `    [${entry?.value ?? '?'}] ${entry?.line ?? ''}`)
+				.join('\n');
+			return `- ${key} (${label})\n${voiceLines || '    (no voice map lines)'}`;
+		})
+		.join('\n');
+
+	const voiceLines = (draft.voiceCeilingLines ?? [])
+		.map((line, index) => `${index + 1}. ${line}`)
+		.join('\n');
+
+	return [
+		`Title: ${draft.title || '(untitled)'}`,
+		`Premise: ${draft.premise || '(empty)'}`,
+		`Setting: ${draft.setting || '(empty)'}`,
+		`Aesthetic statement: ${draft.aestheticStatement || '(empty)'}`,
+		`Voice ceiling lines:\n${voiceLines || '(none)'}`,
+		`Characters:\n${characterSummary || '(none)'}`,
+		`Mechanics:\n${mechanicSummary || '(none)'}`,
+		`Opening prompt: ${draft.openingPrompt || '(empty)'}`,
+		`System prompt: ${draft.systemPrompt || '(empty)'}`
+	].join('\n\n');
+}
+
+function buildAlignmentPrompts(lesson: Lesson, draft: BuilderStoryDraft): {
+	systemPrompt: string;
+	userPrompt: string;
+} {
+	const allowedFields = Array.from(KNOWN_FIELDS).join(', ');
+	const systemPrompt = `You are an editorial alignment evaluator. Given a story builder draft and a target lesson, score how well the draft's fields will surface that lesson when the story is played.
+
+Scoring rubric (1-10):
+- 10: Every load-bearing field directly invokes the lesson's storyTriggers, emotionalStakes, and unconventionalAngle without explaining them.
+- 7-9: The premise and at least one of (openingPrompt, systemPrompt, mechanics) clearly serve the lesson; minor fields drift.
+- 4-6: The draft gestures at the lesson but stages it through trait/feeling words or off-target mechanics.
+- 1-3: The draft does not put the lesson under pressure; mechanics or prompts work against it.
+
+For each field that does not yet serve the lesson, return one gap with:
+- field: one of ${allowedFields} (use the exact key)
+- issue: one specific sentence about what's missing or off
+- suggestion: one specific sentence the author can act on
+
+Check, in order:
+1. Does the premise/setting invoke the lesson's storyTriggers?
+2. Does the openingPrompt set up the emotionalStakes the lesson requires?
+3. Does the systemPrompt's voice/constraint serve the lesson's unconventionalAngle?
+4. Do the mechanics reinforce the lesson or work against it?
+
+Return valid JSON only, with this exact shape:
+{
+  "score": number,
+  "summary": string,
+  "gaps": [{ "field": string, "issue": string, "suggestion": string }]
+}
+
+No prose outside the JSON. No markdown fencing.`;
+
+	const userPrompt = `Lesson #${lesson.id}: ${lesson.title}
+Quote: ${lesson.quote}
+Insight: ${lesson.insight}
+Emotional stakes:
+${lesson.emotionalStakes.map((stake) => `- ${stake}`).join('\n')}
+Story triggers:
+${lesson.storyTriggers.map((trigger) => `- ${trigger}`).join('\n')}
+Unconventional angle: ${lesson.unconventionalAngle}
+
+Builder draft:
+${summarizeDraft(draft)}
+
+Score the alignment. Return JSON only.`;
+
+	return { systemPrompt, userPrompt };
+}
+
+function fallbackAlignment(lesson: Lesson, draft: BuilderStoryDraft): AlignmentResult {
+	const gaps: AlignmentGap[] = [];
+	const triggerWords = lesson.storyTriggers
+		.flatMap((trigger) => trigger.toLowerCase().split(/[^a-z0-9]+/))
+		.filter((word) => word.length > 4);
+	const stakeWords = lesson.emotionalStakes
+		.flatMap((stake) => stake.toLowerCase().split(/[^a-z0-9]+/))
+		.filter((word) => word.length > 4);
+	const angleWords = lesson.unconventionalAngle
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)
+		.filter((word) => word.length > 4);
+
+	function hasOverlap(text: string, words: string[]): boolean {
+		if (!text) return false;
+		const haystack = text.toLowerCase();
+		return words.some((word) => haystack.includes(word));
+	}
+
+	const premiseBlob = `${draft.premise ?? ''} ${draft.setting ?? ''}`.trim();
+	if (!hasOverlap(premiseBlob, triggerWords)) {
+		gaps.push({
+			field: 'premise',
+			issue: 'Premise/setting does not echo any of the lesson’s story triggers.',
+			suggestion: `Reference one concrete trigger, e.g. “${lesson.storyTriggers[0]}”.`
+		});
+	}
+	if (!hasOverlap(draft.openingPrompt ?? '', stakeWords)) {
+		gaps.push({
+			field: 'openingPrompt',
+			issue: 'Opening prompt does not stage the lesson’s emotional stakes.',
+			suggestion: `Open inside the stake “${lesson.emotionalStakes[0]}” — show it as behavior, not naming.`
+		});
+	}
+	if (!hasOverlap(draft.systemPrompt ?? '', angleWords)) {
+		gaps.push({
+			field: 'systemPrompt',
+			issue: 'System prompt does not constrain voice toward the lesson’s unconventional angle.',
+			suggestion: `Add a voice rule pointing at “${lesson.unconventionalAngle}”.`
+		});
+	}
+	if (!(draft.mechanics ?? []).length) {
+		gaps.push({
+			field: 'mechanics',
+			issue: 'No mechanics defined; the lesson has nothing to reinforce it under pressure.',
+			suggestion: 'Add one mechanic whose escalated state stages the lesson’s emotional cost.'
+		});
+	}
+
+	const score = Math.max(1, Math.min(10, 10 - gaps.length * 2));
+	return {
+		score,
+		summary:
+			gaps.length === 0
+				? 'Heuristic fallback: surface-level alignment looks plausible. Re-run when Grok is available for a real score.'
+				: `Heuristic fallback: ${gaps.length} field(s) do not yet invoke this lesson.`,
+		gaps
+	};
+}
+
+export const POST: RequestHandler = async ({ request, locals, url }) => {
+	const payload = (await request.json().catch(() => ({}))) as {
+		draft?: BuilderStoryDraft;
+		lessonId?: unknown;
+	};
+	const draft = payload.draft && typeof payload.draft === 'object' ? payload.draft : null;
+	const lessonId = coerceLessonId(payload.lessonId);
+
+	if (!draft) {
+		return json(
+			{ error: 'Missing builder draft in request body.', code: 'invalid_request' },
+			{ status: 400 }
+		);
+	}
+	if (lessonId === null) {
+		return json(
+			{ error: 'Missing or invalid lessonId in request body.', code: 'invalid_request' },
+			{ status: 400 }
+		);
+	}
+
+	const lesson = getLessonById(lessonId);
+	if (!lesson) {
+		return json(
+			{ error: `Lesson ${lessonId} not found in catalog.`, code: 'lesson_not_found' },
+			{ status: 404 }
+		);
+	}
+
+	const { systemPrompt, userPrompt } = buildAlignmentPrompts(lesson, draft);
+
+	let alignment: AlignmentResult;
+	let source: 'ai' | 'fallback';
+	try {
+		const raw = await callBuilderModel(systemPrompt, userPrompt);
+		const parsed = JSON.parse(extractJsonObject(raw));
+		alignment = normalizeAlignment(parsed);
+		source = 'ai';
+	} catch (error) {
+		console.warn(
+			`[alignment] grok unavailable, using fallback: ${error instanceof Error ? error.message : 'unknown'}`
+		);
+		alignment = fallbackAlignment(lesson, draft);
+		source = 'fallback';
+	}
+
+	emitAiServerTelemetry('builder_audit', {
+		action: 'check_alignment',
+		userId: locals.sessionUser?.userId ?? 'unknown',
+		lessonId,
+		source,
+		score: alignment.score,
+		gapCount: alignment.gaps.length,
+		route: url.pathname
+	});
+
+	const response: AlignmentResponse = {
+		alignment,
+		lesson: { id: lesson.id, title: lesson.title },
+		source
+	};
+	return json(response);
+};

--- a/src/routes/builder/+page.svelte
+++ b/src/routes/builder/+page.svelte
@@ -4,6 +4,8 @@
 	import { starterKitCartridge } from '$lib/stories/starter-kit';
 	import { loadBuilderDraft, saveBuilderDraft } from '$lib/builder/store';
 	import BranchMap, { type BranchMapNode } from '$lib/components/builder/BranchMap.svelte';
+	import AlignmentScore from '$lib/components/builder/AlignmentScore.svelte';
+	import { lessons } from '$lib/narrative/lessonsCatalog';
 	import type {
 		BuilderDraftEvaluation,
 		BuilderDraftFinding,
@@ -34,6 +36,7 @@
 	let findingCounts = { blocker: 0, warning: 0, info: 0 };
 	let activeNodeId: string | null = 'root:story';
 	let branchMapCollapsed = false;
+	let alignmentLessonId: string = lessons[0] ? String(lessons[0].id) : '';
 
 	onMount(() => {
 		draft = loadBuilderDraft(draftScope, fallbackDraft);
@@ -689,6 +692,17 @@
 					</div>
 				{/if}
 			</div>
+			<div class="builder-rail-card builder-rail-alignment" data-testid="builder-alignment">
+				<label class="builder-rail-alignment-picker" for="builder-alignment-lesson">
+					<span>Lesson to align against</span>
+					<select id="builder-alignment-lesson" class="builder-input" bind:value={alignmentLessonId}>
+						{#each lessons as lesson (lesson.id)}
+							<option value={String(lesson.id)}>#{lesson.id} — {lesson.title}</option>
+						{/each}
+					</select>
+				</label>
+				<AlignmentScore {draft} lessonId={alignmentLessonId} />
+			</div>
 			<div class="builder-rail-card">
 				<h3>Gold medal bar</h3>
 				<p class="builder-rail-copy">
@@ -743,5 +757,26 @@
 
 	.builder-rail-branch-map-head h3 {
 		margin: 0;
+	}
+
+	.builder-rail-alignment {
+		display: grid;
+		gap: 0.75rem;
+		padding: 0.75rem;
+	}
+
+	.builder-rail-alignment-picker {
+		display: grid;
+		gap: 0.35rem;
+		font-size: 0.78rem;
+		color: var(--text-300, #b8aa9d);
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+	}
+
+	.builder-rail-alignment-picker select {
+		text-transform: none;
+		letter-spacing: normal;
+		font-size: 0.9rem;
 	}
 </style>


### PR DESCRIPTION
## Summary

Adds a Lesson Alignment Score panel to the story builder. After the author picks a target lesson and clicks **Check alignment**, the panel calls Grok with the current `BuilderStoryDraft` and the selected `Lesson` (from `src/lib/narrative/lessonsCatalog.ts`) and renders a 1-10 score plus a list of field-level gaps.

## What ships

- **New** `src/lib/components/builder/AlignmentScore.svelte` — props `{ draft, lessonId, title? }`. Renders a colour-graded meter (amber for low, green for high) using the same palette tokens as `BranchMap.svelte` (`--accent-bright`, `--amber-400`, `--sage-400`, `--text-100/300`, `--line-soft/strong`). Each returned gap displays the field name, the issue, and a one-line suggestion.
- **New** `src/routes/api/builder/alignment/+server.ts` — POST `{ draft, lessonId }`. Coerces `lessonId` to a number (`getLessonById` takes `number`), 400s on missing draft/lessonId, 404s when the lesson is not in catalog. Calls Grok via the existing `callBuilderModel` client (no new AI client instantiated). Normalises Grok's JSON via `extractJsonObject`, clamps the score to 1-10, and falls back to a deterministic heuristic alignment (keyword overlap of `storyTriggers`/`emotionalStakes`/`unconventionalAngle` against the draft fields) when Grok times out or returns invalid JSON. Telemetry emitted via `emitAiServerTelemetry('builder_audit', { action: 'check_alignment', ... })` to match the other builder routes.
- **Modified** `src/routes/builder/+page.svelte` — adds the `AlignmentScore` import, a `lessons` import for the picker, an `alignmentLessonId` state defaulting to lesson #1, and a new rail card mounted immediately below the existing BranchMap card. **BranchMap is untouched.**

## Alignment rubric the prompt asks Grok to apply

1. Does the premise/setting invoke the lesson's `storyTriggers`?
2. Does the `openingPrompt` set up the `emotionalStakes` the lesson requires?
3. Does the `systemPrompt`'s voice/constraint serve the lesson's `unconventionalAngle`?
4. Do the `mechanics` reinforce the lesson or work against it?

Grok must respond JSON-only: `{ score: number, summary: string, gaps: { field, issue, suggestion }[] }`.

## Constraints honoured

- Svelte 4 idioms (`export let`, `$:`, `on:click`) throughout.
- TypeScript everywhere.
- No new npm dependencies.
- Reuses `callBuilderModel`, `extractJsonObject`, `emitAiServerTelemetry` — no new AI client.
- Sprint 13 `BranchMap` integration preserved verbatim.

## Test plan

- [ ] `pnpm dev`, open `/builder`, confirm both BranchMap and Alignment cards render in the rail in that order.
- [ ] With Grok configured, click **Check alignment** for the default draft / lesson 1; expect a score 1-10 and at least one gap referencing a known field key.
- [ ] Pick a different lesson from the dropdown, re-check, confirm `lesson.title` in the response matches.
- [ ] With `XAI_API_KEY` unset, confirm the fallback path returns a heuristic score and gaps without throwing.
- [ ] POST `/api/builder/alignment` with missing `lessonId` returns 400; with `lessonId: 9999` returns 404.
- [ ] Confirm meter colour transitions: scores ≤4 amber, 5-7 amber, ≥8 green.