### PR TITLE
feat(sprint-15): Sydney voice evaluator for builder

### DIFF
--- a/src/lib/components/builder/VoiceEvaluator.svelte
+++ b/src/lib/components/builder/VoiceEvaluator.svelte
@@ -1,0 +1,464 @@
+<script lang="ts" context="module">
+	export interface VoiceLineEvaluation {
+		moment: string;
+		text: string;
+		flags: string[];
+		isClean: boolean;
+	}
+
+	export interface VoiceEvaluationResult {
+		lines: VoiceLineEvaluation[];
+		overallVoiceScore: number;
+		summary: string;
+	}
+
+	export interface VoiceEvaluationResponsePayload {
+		evaluation: VoiceEvaluationResult;
+		source: 'ai' | 'fallback';
+	}
+</script>
+
+<script lang="ts">
+	import type { BuilderStoryDraft } from '$lib/stories/types';
+
+	export let draft: BuilderStoryDraft;
+	export let title: string = "What would Sydney do?";
+
+	type ViewState = 'idle' | 'loading' | 'ready' | 'error';
+
+	let viewState: ViewState = 'idle';
+	let errorMessage = '';
+	let result: VoiceEvaluationResult | null = null;
+	let resultSource: 'ai' | 'fallback' | null = null;
+
+	$: scoreTone = result ? toneForScore(result.overallVoiceScore) : 'neutral';
+	$: meterPercent = result
+		? Math.max(0, Math.min(100, (result.overallVoiceScore / 10) * 100))
+		: 0;
+	$: flaggedCount = result ? result.lines.filter((line) => !line.isClean).length : 0;
+
+	function toneForScore(score: number): 'low' | 'mid' | 'high' {
+		if (score <= 4) return 'low';
+		if (score <= 7) return 'mid';
+		return 'high';
+	}
+
+	async function runVoiceCheck(): Promise<void> {
+		viewState = 'loading';
+		errorMessage = '';
+		try {
+			const response = await fetch('/api/builder/evaluate-voice', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ draft })
+			});
+			const payload = (await response.json().catch(() => ({}))) as Partial<
+				VoiceEvaluationResponsePayload & { error: string }
+			>;
+			if (!response.ok || !payload.evaluation) {
+				throw new Error(payload.error || `Voice evaluation failed (${response.status}).`);
+			}
+			result = payload.evaluation;
+			resultSource = payload.source ?? null;
+			viewState = 'ready';
+		} catch (error) {
+			viewState = 'error';
+			errorMessage =
+				error instanceof Error ? error.message : 'Voice evaluation failed unexpectedly.';
+		}
+	}
+</script>
+
+<section class="voice-evaluator" aria-label={title}>
+	<header class="voice-head">
+		<div>
+			<p class="voice-kicker">Authoring signal</p>
+			<h3>{title}</h3>
+		</div>
+		<button
+			type="button"
+			class="voice-button"
+			on:click={runVoiceCheck}
+			disabled={viewState === 'loading'}
+			data-testid="voice-evaluator-run"
+		>
+			{viewState === 'loading' ? 'Testing…' : result ? 'Re-test' : "Test Sydney's voice"}
+		</button>
+	</header>
+
+	{#if viewState === 'idle'}
+		<p class="voice-empty">
+			Generates five sample Sydney lines from the current voice constraints, then flags lines
+			where she sounds too articulate, too self-aware, or out of register.
+		</p>
+	{:else if viewState === 'loading'}
+		<p class="voice-empty" aria-live="polite">Asking Grok to put Sydney in five different moments…</p>
+	{:else if viewState === 'error'}
+		<p class="voice-error" role="alert">{errorMessage}</p>
+	{:else if viewState === 'ready' && result}
+		<div class="voice-result">
+			<div class="voice-meta">
+				{#if resultSource}
+					<p class="voice-source">
+						Source: {resultSource === 'ai' ? 'Grok evaluator' : 'Heuristic fallback'}
+					</p>
+				{/if}
+				<p class="voice-flagged">
+					Flagged: <strong>{flaggedCount}</strong> / {result.lines.length}
+				</p>
+			</div>
+
+			<div
+				class="voice-meter"
+				class:is-low={scoreTone === 'low'}
+				class:is-mid={scoreTone === 'mid'}
+				class:is-high={scoreTone === 'high'}
+				role="img"
+				aria-label="Voice score {result.overallVoiceScore} of 10"
+			>
+				<div class="voice-meter-track">
+					<div class="voice-meter-fill" style="width: {meterPercent}%"></div>
+				</div>
+				<div class="voice-meter-readout">
+					<span class="voice-score-number">{result.overallVoiceScore}</span>
+					<span class="voice-score-suffix">/ 10</span>
+				</div>
+			</div>
+
+			<p class="voice-summary">{result.summary}</p>
+
+			{#if result.lines.length === 0}
+				<p class="voice-empty">No sample lines returned.</p>
+			{:else}
+				<ul class="voice-lines">
+					{#each result.lines as line, index (index)}
+						<li
+							class="voice-line"
+							class:is-clean={line.isClean}
+							class:is-flagged={!line.isClean}
+						>
+							<div class="voice-line-head">
+								<p class="voice-line-moment">{line.moment}</p>
+								{#if line.isClean}
+									<span class="voice-line-badge voice-line-badge-clean" aria-label="Clean line">
+										<svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+											<path
+												d="M3.5 8.5l3 3 6-7"
+												fill="none"
+												stroke="currentColor"
+												stroke-width="2"
+												stroke-linecap="round"
+												stroke-linejoin="round"
+											/>
+										</svg>
+										Clean
+									</span>
+								{:else}
+									<span
+										class="voice-line-badge voice-line-badge-flag"
+										aria-label="Flagged line"
+									>
+										<svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+											<path
+												d="M8 1.5l7 12H1l7-12z"
+												fill="none"
+												stroke="currentColor"
+												stroke-width="1.6"
+												stroke-linejoin="round"
+											/>
+											<path
+												d="M8 6v4"
+												stroke="currentColor"
+												stroke-width="1.6"
+												stroke-linecap="round"
+											/>
+											<circle cx="8" cy="12" r="0.9" fill="currentColor" />
+										</svg>
+										Flagged
+									</span>
+								{/if}
+							</div>
+							<blockquote class="voice-line-quote">{line.text}</blockquote>
+							{#if !line.isClean && line.flags.length > 0}
+								<ul class="voice-line-flags">
+									{#each line.flags as flag, flagIndex (flagIndex)}
+										<li>{flag}</li>
+									{/each}
+								</ul>
+							{/if}
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
+	{/if}
+</section>
+
+<style>
+	.voice-evaluator {
+		--voice-accent: var(--accent-bright, #6366f1);
+		--voice-low: var(--amber-400, #f59e0b);
+		--voice-mid: var(--amber-400, #f59e0b);
+		--voice-high: var(--sage-400, #22c55e);
+		--voice-card-bg: rgba(18, 12, 9, 0.92);
+		--voice-card-border: var(--line-soft, rgba(247, 241, 232, 0.12));
+		--voice-card-border-strong: var(--line-strong, rgba(247, 241, 232, 0.22));
+		--voice-text: var(--text-100, #f7f1e8);
+		--voice-text-dim: var(--text-300, #b8aa9d);
+		display: grid;
+		gap: 0.85rem;
+		padding: 1rem;
+		border: 1px solid var(--voice-card-border);
+		border-radius: 16px;
+		background: linear-gradient(180deg, rgba(18, 12, 9, 0.92), rgba(10, 8, 7, 0.96));
+		box-shadow: var(--shadow-md, 0 16px 36px rgba(0, 0, 0, 0.22));
+		color: var(--voice-text);
+	}
+
+	.voice-head {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 0.75rem;
+	}
+
+	.voice-head h3 {
+		margin: 0.1rem 0 0;
+		font-family: var(--font-display, serif);
+		font-size: 1.1rem;
+		color: var(--voice-text);
+	}
+
+	.voice-kicker {
+		margin: 0;
+		text-transform: uppercase;
+		letter-spacing: 0.14em;
+		font-size: 0.68rem;
+		color: var(--voice-text-dim);
+	}
+
+	.voice-button {
+		appearance: none;
+		border: 1px solid var(--voice-card-border-strong);
+		background: rgba(247, 241, 232, 0.04);
+		color: var(--voice-text);
+		font: inherit;
+		font-size: 0.82rem;
+		padding: 0.45rem 0.85rem;
+		border-radius: 8px;
+		cursor: pointer;
+		transition: background 120ms ease-out, border-color 120ms ease-out;
+	}
+
+	.voice-button:hover:not(:disabled) {
+		background: rgba(247, 241, 232, 0.08);
+		border-color: var(--voice-accent);
+	}
+
+	.voice-button:disabled {
+		cursor: not-allowed;
+		opacity: 0.55;
+	}
+
+	.voice-empty {
+		margin: 0;
+		padding: 0.85rem;
+		border: 1px dashed var(--voice-card-border-strong);
+		border-radius: 12px;
+		color: var(--voice-text-dim);
+		font-size: 0.88rem;
+	}
+
+	.voice-error {
+		margin: 0;
+		padding: 0.85rem;
+		border: 1px solid var(--voice-low);
+		border-radius: 12px;
+		color: var(--voice-text);
+		background: rgba(245, 158, 11, 0.08);
+		font-size: 0.88rem;
+	}
+
+	.voice-result {
+		display: grid;
+		gap: 0.85rem;
+	}
+
+	.voice-meta {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
+		gap: 0.4rem;
+		font-size: 0.78rem;
+		color: var(--voice-text-dim);
+	}
+
+	.voice-meta p {
+		margin: 0;
+	}
+
+	.voice-flagged strong {
+		color: var(--voice-text);
+		font-weight: 600;
+	}
+
+	.voice-meter {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		align-items: center;
+		gap: 0.85rem;
+	}
+
+	.voice-meter-track {
+		height: 12px;
+		border-radius: 999px;
+		background: rgba(247, 241, 232, 0.08);
+		border: 1px solid var(--voice-card-border-strong);
+		overflow: hidden;
+	}
+
+	.voice-meter-fill {
+		height: 100%;
+		transition: width 240ms ease-out, background 240ms ease-out;
+		background: var(--voice-mid);
+	}
+
+	.voice-meter.is-low .voice-meter-fill {
+		background: var(--voice-low);
+	}
+
+	.voice-meter.is-mid .voice-meter-fill {
+		background: var(--voice-mid);
+	}
+
+	.voice-meter.is-high .voice-meter-fill {
+		background: var(--voice-high);
+	}
+
+	.voice-meter-readout {
+		display: inline-flex;
+		align-items: baseline;
+		gap: 0.15rem;
+		font-family: var(--font-mono, monospace);
+		color: var(--voice-text);
+	}
+
+	.voice-meter.is-low .voice-meter-readout {
+		color: var(--voice-low);
+	}
+
+	.voice-meter.is-high .voice-meter-readout {
+		color: var(--voice-high);
+	}
+
+	.voice-score-number {
+		font-size: 1.55rem;
+		font-weight: 700;
+	}
+
+	.voice-score-suffix {
+		font-size: 0.85rem;
+		color: var(--voice-text-dim);
+	}
+
+	.voice-summary {
+		margin: 0;
+		font-size: 0.92rem;
+		color: var(--voice-text);
+		line-height: 1.4;
+	}
+
+	.voice-lines {
+		list-style: none;
+		display: grid;
+		gap: 0.6rem;
+		margin: 0;
+		padding: 0;
+	}
+
+	.voice-line {
+		display: grid;
+		gap: 0.4rem;
+		padding: 0.7rem 0.8rem;
+		border: 1px solid var(--voice-card-border-strong);
+		border-radius: 10px;
+		background: rgba(9, 7, 7, 0.55);
+	}
+
+	.voice-line.is-clean {
+		border-left: 3px solid var(--voice-high);
+	}
+
+	.voice-line.is-flagged {
+		border-left: 3px solid var(--voice-low);
+	}
+
+	.voice-line-head {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 0.6rem;
+	}
+
+	.voice-line-moment {
+		margin: 0;
+		font-size: 0.78rem;
+		color: var(--voice-text-dim);
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		line-height: 1.35;
+	}
+
+	.voice-line-badge {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3rem;
+		flex-shrink: 0;
+		font-size: 0.68rem;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		font-weight: 700;
+		padding: 0.15rem 0.45rem;
+		border-radius: 999px;
+		border: 1px solid transparent;
+	}
+
+	.voice-line-badge-clean {
+		color: var(--voice-high);
+		border-color: rgba(34, 197, 94, 0.4);
+		background: rgba(34, 197, 94, 0.08);
+	}
+
+	.voice-line-badge-flag {
+		color: var(--voice-low);
+		border-color: rgba(245, 158, 11, 0.4);
+		background: rgba(245, 158, 11, 0.08);
+	}
+
+	.voice-line-quote {
+		margin: 0;
+		padding: 0.5rem 0.75rem;
+		border-left: 2px solid var(--voice-card-border-strong);
+		color: var(--voice-text);
+		font-family: var(--font-display, serif);
+		font-style: italic;
+		font-size: 0.95rem;
+		line-height: 1.45;
+	}
+
+	.voice-line-flags {
+		list-style: disc;
+		padding-left: 1.1rem;
+		margin: 0;
+		display: grid;
+		gap: 0.2rem;
+		color: var(--voice-text-dim);
+		font-size: 0.82rem;
+		line-height: 1.4;
+	}
+
+	.voice-line-flags li {
+		margin: 0;
+	}
+</style>

--- a/src/routes/api/builder/evaluate-voice/+server.ts
+++ b/src/routes/api/builder/evaluate-voice/+server.ts
@@ -1,0 +1,252 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { callBuilderModel } from '$lib/server/ai/builder/modelClient';
+import { extractJsonObject } from '$lib/server/ai/builder/normalizers';
+import { emitAiServerTelemetry } from '$lib/server/ai/telemetry';
+import type { BuilderStoryDraft } from '$lib/stories/types';
+
+export interface VoiceLineEvaluation {
+	moment: string;
+	text: string;
+	flags: string[];
+	isClean: boolean;
+}
+
+export interface VoiceEvaluationResult {
+	lines: VoiceLineEvaluation[];
+	overallVoiceScore: number;
+	summary: string;
+}
+
+export interface VoiceEvaluationResponse {
+	evaluation: VoiceEvaluationResult;
+	source: 'ai' | 'fallback';
+}
+
+const SYDNEY_MOMENTS: readonly string[] = [
+	'Receiving a low rating from a customer.',
+	'Being asked to pick up more shifts on top of an already-long day.',
+	'Explaining her situation to a stranger who has just asked what she does for work.',
+	'Deciding in the moment whether to accept another booking when she is already past her limit.',
+	'Noticing, in passing, that she has not slept in a long time.'
+];
+
+function clampScore(value: unknown): number {
+	if (typeof value !== 'number' || !Number.isFinite(value)) return 1;
+	return Math.max(1, Math.min(10, Math.round(value)));
+}
+
+function normalizeFlags(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	const out: string[] = [];
+	for (const raw of value) {
+		if (typeof raw !== 'string') continue;
+		const trimmed = raw.trim();
+		if (!trimmed) continue;
+		out.push(trimmed);
+	}
+	return out;
+}
+
+function normalizeLines(value: unknown): VoiceLineEvaluation[] {
+	if (!Array.isArray(value)) return [];
+	const out: VoiceLineEvaluation[] = [];
+	for (let index = 0; index < value.length; index++) {
+		const raw = value[index];
+		if (!raw || typeof raw !== 'object') continue;
+		const typed = raw as Partial<VoiceLineEvaluation>;
+		const moment =
+			typeof typed.moment === 'string' && typed.moment.trim()
+				? typed.moment.trim()
+				: SYDNEY_MOMENTS[index] ?? `Moment ${index + 1}`;
+		const text =
+			typeof typed.text === 'string' && typed.text.trim()
+				? typed.text.trim()
+				: '(no line returned)';
+		const flags = normalizeFlags(typed.flags);
+		const isClean = typeof typed.isClean === 'boolean' ? typed.isClean : flags.length === 0;
+		out.push({ moment, text, flags, isClean });
+	}
+	return out;
+}
+
+function normalizeEvaluation(candidate: unknown): VoiceEvaluationResult {
+	if (!candidate || typeof candidate !== 'object') {
+		return {
+			lines: [],
+			overallVoiceScore: 1,
+			summary: 'Evaluator returned an invalid payload.'
+		};
+	}
+	const typed = candidate as Partial<VoiceEvaluationResult>;
+	const lines = normalizeLines(typed.lines);
+	const summary =
+		typeof typed.summary === 'string' && typed.summary.trim()
+			? typed.summary.trim()
+			: lines.length === 0
+				? 'No sample lines were returned.'
+				: 'No summary returned.';
+	return {
+		lines,
+		overallVoiceScore: clampScore(typed.overallVoiceScore),
+		summary
+	};
+}
+
+function buildVoicePrompts(draft: BuilderStoryDraft): {
+	systemPrompt: string;
+	userPrompt: string;
+} {
+	const momentsList = SYDNEY_MOMENTS.map((moment, index) => `${index + 1}. ${moment}`).join('\n');
+	const voiceLines = (draft.voiceCeilingLines ?? [])
+		.map((line, index) => `${index + 1}. ${line}`)
+		.join('\n');
+
+	const systemPrompt = `You are a voice consistency evaluator for the story protagonist "Sydney" — a gig worker who has become infrastructure. She is so embedded in the platforms that she cannot see it clearly.
+
+Sydney's voice ceiling:
+- Tired but still hustling.
+- Practical, not philosophical.
+- She rationalises her situation; she does NOT have insight into it.
+- She would NOT say anything that signals she understands she is being exploited.
+- She would NOT use corporate/platform language ironically — when she uses it, she means it sincerely.
+- She would NOT be articulate about her own condition, self-aware about systems, or eloquent about labour.
+- She would NOT be passive or resigned in a literary way; she is busy.
+
+You will do two things in one response:
+
+Part 1 — Generate: Write exactly 5 sample lines Sydney might say, one for each of the moments listed in the user prompt, in order. Keep each line short (one or two sentences), in-character, in Sydney's actual mouth. Use the draft's systemPrompt and voiceCeilingLines as the binding voice constraint.
+
+Part 2 — Evaluate: For each generated line, decide whether it violates the ceiling or feels off-character. Flag specific failure modes you observe. Use flags drawn from this vocabulary when they fit, and add other specific notes when they don't:
+- "too self-aware" — she understands her own exploitation
+- "too articulate" — sentence-level eloquence she would not have
+- "too philosophical" — abstracts instead of describing the next concrete thing
+- "too passive" — resigned/literary instead of busy/hustling
+- "ironic corporate-speak" — uses platform language with distance instead of sincerity
+- "out of register" — wrong vocabulary, wrong rhythm, wrong concreteness
+- "explains the theme" — names the lesson the story is meant to surface
+
+Mark a line isClean: true ONLY if it sounds like Sydney across every dimension.
+
+Then score the draft's voice constraints (its systemPrompt + voiceCeilingLines) from 1–10 on how reliably they would produce a Sydney that sounds right across random generations:
+- 10: Every generated line lands clean; the constraints fully bind voice.
+- 7–9: Most lines clean; one or two soft flags.
+- 4–6: Mixed; constraints permit too much drift.
+- 1–3: Constraints fail; Sydney comes out wrong (too articulate, too self-aware, off register).
+
+Return valid JSON only, with this exact shape:
+{
+  "lines": [
+    { "moment": string, "text": string, "flags": string[], "isClean": boolean }
+  ],
+  "overallVoiceScore": number,
+  "summary": string
+}
+
+No prose outside the JSON. No markdown fencing. Exactly 5 entries in lines, in the same order as the moments.`;
+
+	const userPrompt = `Draft voice constraints to evaluate.
+
+System prompt:
+${draft.systemPrompt?.trim() || '(empty)'}
+
+Voice ceiling lines:
+${voiceLines || '(none)'}
+
+Aesthetic statement:
+${draft.aestheticStatement?.trim() || '(empty)'}
+
+Moments (generate one Sydney line per moment, in order):
+${momentsList}
+
+Return JSON only.`;
+
+	return { systemPrompt, userPrompt };
+}
+
+function fallbackEvaluation(draft: BuilderStoryDraft): VoiceEvaluationResult {
+	const constraintBlob = `${draft.systemPrompt ?? ''} ${(draft.voiceCeilingLines ?? []).join(' ')}`
+		.toLowerCase()
+		.trim();
+	const hasConstraints = constraintBlob.length > 0;
+	const ceilingCount = (draft.voiceCeilingLines ?? []).filter(
+		(line) => typeof line === 'string' && line.trim().length > 0
+	).length;
+
+	const lines: VoiceLineEvaluation[] = SYDNEY_MOMENTS.map((moment, index) => {
+		const flags: string[] = [];
+		if (!hasConstraints) {
+			flags.push('No systemPrompt or voiceCeilingLines provided — Sydney cannot be bound.');
+		}
+		if (ceilingCount < 2) {
+			flags.push('Voice ceiling has fewer than two lines; voice will drift.');
+		}
+		return {
+			moment,
+			text: `(fallback) Sample line ${index + 1} could not be generated; Grok is unavailable.`,
+			flags,
+			isClean: false
+		};
+	});
+
+	const overallVoiceScore = Math.max(
+		1,
+		Math.min(10, hasConstraints ? Math.max(1, ceilingCount * 2) : 1)
+	);
+	return {
+		lines,
+		overallVoiceScore,
+		summary:
+			'Heuristic fallback: Grok was unavailable, so no real sample lines were generated. Re-run when AI is configured to see whether the constraints actually produce a Sydney that sounds right.'
+	};
+}
+
+export const POST: RequestHandler = async ({ request, locals, url }) => {
+	const payload = (await request.json().catch(() => ({}))) as {
+		draft?: BuilderStoryDraft;
+	};
+	const draft = payload.draft && typeof payload.draft === 'object' ? payload.draft : null;
+
+	if (!draft) {
+		return json(
+			{ error: 'Missing builder draft in request body.', code: 'invalid_request' },
+			{ status: 400 }
+		);
+	}
+
+	const { systemPrompt, userPrompt } = buildVoicePrompts(draft);
+
+	let evaluation: VoiceEvaluationResult;
+	let source: 'ai' | 'fallback';
+	try {
+		const raw = await callBuilderModel(systemPrompt, userPrompt);
+		const parsed = JSON.parse(extractJsonObject(raw));
+		evaluation = normalizeEvaluation(parsed);
+		if (evaluation.lines.length === 0) {
+			throw new Error('Evaluator returned no sample lines.');
+		}
+		source = 'ai';
+	} catch (error) {
+		console.warn(
+			`[evaluate-voice] grok unavailable, using fallback: ${
+				error instanceof Error ? error.message : 'unknown'
+			}`
+		);
+		evaluation = fallbackEvaluation(draft);
+		source = 'fallback';
+	}
+
+	const flaggedCount = evaluation.lines.filter((line) => !line.isClean).length;
+
+	emitAiServerTelemetry('builder_audit', {
+		action: 'evaluate_voice',
+		userId: locals.sessionUser?.userId ?? 'unknown',
+		source,
+		score: evaluation.overallVoiceScore,
+		lineCount: evaluation.lines.length,
+		flaggedCount,
+		route: url.pathname
+	});
+
+	const response: VoiceEvaluationResponse = { evaluation, source };
+	return json(response);
+};

--- a/src/routes/builder/+page.svelte
+++ b/src/routes/builder/+page.svelte
@@ -5,6 +5,7 @@
 	import { loadBuilderDraft, saveBuilderDraft } from '$lib/builder/store';
 	import BranchMap, { type BranchMapNode } from '$lib/components/builder/BranchMap.svelte';
 	import AlignmentScore from '$lib/components/builder/AlignmentScore.svelte';
+	import VoiceEvaluator from '$lib/components/builder/VoiceEvaluator.svelte';
 	import { lessons } from '$lib/narrative/lessonsCatalog';
 	import type {
 		BuilderDraftEvaluation,
@@ -703,6 +704,9 @@
 				</label>
 				<AlignmentScore {draft} lessonId={alignmentLessonId} />
 			</div>
+			<div class="builder-rail-card builder-rail-voice" data-testid="builder-voice-evaluator">
+				<VoiceEvaluator {draft} />
+			</div>
 			<div class="builder-rail-card">
 				<h3>Gold medal bar</h3>
 				<p class="builder-rail-copy">
@@ -778,5 +782,9 @@
 		text-transform: none;
 		letter-spacing: normal;
 		font-size: 0.9rem;
+	}
+
+	.builder-rail-voice {
+		padding: 0.75rem;
 	}
 </style>


### PR DESCRIPTION
## Summary

Adds the **What Would Sydney Do?** voice evaluator to the story builder rail — Sprint 15 of the No Vacancies builder track.

The panel sends the current draft's `systemPrompt` and `voiceCeilingLines` to Grok with five canonical Sydney moments and asks it to (a) generate one in-character Sydney line per moment, then (b) evaluate each generated line against the voice ceiling. Lines that drift — too articulate, too self-aware, too philosophical, passive, ironic about corporate-speak, out of register, or explaining the theme — are flagged with specific notes. An overall 1–10 voice score tells you whether the constraints would reliably bind voice across random generations.

### What's new

- **`src/routes/api/builder/evaluate-voice/+server.ts`** (new) — POST endpoint reusing `callBuilderModel` and `extractJsonObject` (same pattern as the Sprint 14 alignment route). Returns `{ evaluation: { lines, overallVoiceScore, summary }, source }` and emits `builder_audit` telemetry. Includes a heuristic fallback when Grok is unreachable.
- **`src/lib/components/builder/VoiceEvaluator.svelte`** (new) — Rail card mirroring `AlignmentScore.svelte`'s visual language: same kicker / title / button layout, same 1–10 meter with tone classes (`is-low`/`is-mid`/`is-high`), same CSS variable surface (`--text-100`, `--line-soft`, `--sage-400`, `--amber-400`, etc.). Each sample line renders in a blockquote with a clean-checkmark or flagged-warning badge and the specific flag notes below flagged lines.
- **`src/routes/builder/+page.svelte`** (modified) — Imports `VoiceEvaluator` and mounts it as the third rail card, below `AlignmentScore`. BranchMap (Sprint 13) and AlignmentScore (Sprint 14) integrations are untouched.

### Sydney moments used

1. Receiving a low rating from a customer.
2. Being asked to pick up more shifts on top of an already-long day.
3. Explaining her situation to a stranger who has just asked what she does for work.
4. Deciding in the moment whether to accept another booking when she is already past her limit.
5. Noticing, in passing, that she has not slept in a long time.

### Flag vocabulary surfaced to Grok

`too self-aware`, `too articulate`, `too philosophical`, `too passive`, `ironic corporate-speak`, `out of register`, `explains the theme` — plus open-ended notes when none of those fit.

## Test plan

- [ ] Open `/builder`, confirm the new card renders below `AlignmentScore` in the rail.
- [ ] Click **Test Sydney's voice** with the starter-kit draft and verify the request hits `/api/builder/evaluate-voice`.
- [ ] Confirm response shape: `{ evaluation: { lines: [{ moment, text, flags, isClean }], overallVoiceScore: number, summary: string }, source: 'ai' | 'fallback' }`.
- [ ] Verify five sample lines render, each with a moment label, a blockquote line, and either a clean-check badge or a flagged-warning badge with specific flag notes below.
- [ ] Verify the 1–10 meter colour tracks the score (low → amber, high → sage), matching `AlignmentScore` exactly.
- [ ] Force the fallback path (kill Grok creds / point at a bad URL) and confirm the fallback summary explains that Grok was unavailable and the card still renders without error.
- [ ] Confirm `BranchMap` and `AlignmentScore` cards continue to behave (selection, lesson picker, re-check) — no regressions.
- [ ] `npm run check` and `npm run lint` pass (Svelte 4 idioms preserved; no new npm deps).

## Notes

- No new dependencies. Reuses `callBuilderModel`, `extractJsonObject`, `emitAiServerTelemetry`.
- Svelte 4 idioms throughout (`export let`, reactive `$:`, `on:click`).
- TypeScript across server route and component module script.