### PR TITLE
feat(sprint-16): draft version snapshots and diff view for builder

### DIFF
--- a/src/lib/components/builder/DraftDiff.svelte
+++ b/src/lib/components/builder/DraftDiff.svelte
@@ -1,0 +1,656 @@
+<script lang="ts" context="module">
+	export interface SnapshotSummary {
+		id: string;
+		draft_title: string;
+		created_at: string;
+	}
+
+	export interface SnapshotDetail {
+		id: string;
+		draft_title: string;
+		created_at: string;
+		snapshot: import('$lib/stories/types').BuilderStoryDraft;
+	}
+
+	export type DiffEntryKind = 'string' | 'array';
+
+	export interface StringDiffEntry {
+		field: string;
+		kind: 'string';
+		oldValue: string;
+		newValue: string;
+	}
+
+	export interface ArrayDiffEntry {
+		field: string;
+		kind: 'array';
+		oldCount: number;
+		newCount: number;
+		added: string[];
+		removed: string[];
+	}
+
+	export type DiffEntry = StringDiffEntry | ArrayDiffEntry;
+</script>
+
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import type { BuilderStoryDraft } from '$lib/stories/types';
+
+	export let currentDraft: BuilderStoryDraft;
+	export let snapshotId: string | null = null;
+
+	type ViewState = 'idle' | 'loading' | 'ready' | 'error';
+	type SaveState = 'idle' | 'saving' | 'saved' | 'error';
+
+	const STRING_FIELDS: Array<keyof BuilderStoryDraft> = [
+		'title',
+		'premise',
+		'setting',
+		'aestheticStatement',
+		'openingPrompt',
+		'systemPrompt'
+	];
+	const TRUNCATE_AT = 120;
+
+	const dispatch = createEventDispatcher<{
+		snapshotSelected: { id: string | null };
+		snapshotSaved: { id: string; createdAt: string };
+	}>();
+
+	let snapshots: SnapshotSummary[] = [];
+	let listState: ViewState = 'idle';
+	let listError = '';
+
+	let detail: SnapshotDetail | null = null;
+	let detailState: ViewState = 'idle';
+	let detailError = '';
+
+	let saveState: SaveState = 'idle';
+	let saveError = '';
+
+	let selectedId: string | null = snapshotId;
+
+	$: if (snapshotId !== selectedId) {
+		selectedId = snapshotId;
+	}
+
+	$: void loadSnapshotDetail(selectedId);
+
+	$: diffEntries = detail ? computeDiff(detail.snapshot, currentDraft) : [];
+
+	async function refreshSnapshotList(): Promise<void> {
+		listState = 'loading';
+		listError = '';
+		try {
+			const response = await fetch('/api/builder/snapshots');
+			const payload = (await response.json().catch(() => ({}))) as {
+				snapshots?: SnapshotSummary[];
+				error?: string;
+			};
+			if (!response.ok) {
+				throw new Error(payload.error || `Failed to load snapshots (${response.status}).`);
+			}
+			snapshots = payload.snapshots ?? [];
+			listState = 'ready';
+		} catch (error) {
+			listState = 'error';
+			listError = error instanceof Error ? error.message : 'Failed to load snapshots.';
+		}
+	}
+
+	async function loadSnapshotDetail(id: string | null): Promise<void> {
+		if (!id) {
+			detail = null;
+			detailState = 'idle';
+			detailError = '';
+			return;
+		}
+		detailState = 'loading';
+		detailError = '';
+		try {
+			const response = await fetch(`/api/builder/snapshot/${encodeURIComponent(id)}`);
+			const payload = (await response.json().catch(() => ({}))) as Partial<SnapshotDetail> & {
+				error?: string;
+			};
+			if (!response.ok || !payload.snapshot) {
+				throw new Error(payload.error || `Failed to load snapshot (${response.status}).`);
+			}
+			detail = payload as SnapshotDetail;
+			detailState = 'ready';
+		} catch (error) {
+			detailState = 'error';
+			detailError = error instanceof Error ? error.message : 'Failed to load snapshot.';
+		}
+	}
+
+	async function saveSnapshot(): Promise<void> {
+		saveState = 'saving';
+		saveError = '';
+		try {
+			const response = await fetch('/api/builder/snapshot', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ draft: currentDraft })
+			});
+			const payload = (await response.json().catch(() => ({}))) as {
+				id?: string;
+				created_at?: string;
+				error?: string;
+			};
+			if (!response.ok || !payload.id || !payload.created_at) {
+				throw new Error(payload.error || `Failed to save snapshot (${response.status}).`);
+			}
+			saveState = 'saved';
+			dispatch('snapshotSaved', { id: payload.id, createdAt: payload.created_at });
+			await refreshSnapshotList();
+		} catch (error) {
+			saveState = 'error';
+			saveError = error instanceof Error ? error.message : 'Failed to save snapshot.';
+		}
+	}
+
+	function handleSelectChange(event: Event): void {
+		const target = event.currentTarget as HTMLSelectElement;
+		const value = target.value || null;
+		selectedId = value;
+		dispatch('snapshotSelected', { id: value });
+	}
+
+	function truncate(value: string): string {
+		if (!value) return '';
+		if (value.length <= TRUNCATE_AT) return value;
+		return `${value.slice(0, TRUNCATE_AT)}…`;
+	}
+
+	function describeArrayItem(item: unknown, fieldKey: string): string {
+		if (item == null) return '(empty)';
+		if (typeof item === 'string') return item;
+		if (typeof item !== 'object') return String(item);
+		// Characters: { name, role, description }
+		// Mechanics: { key, label, voiceMap }
+		const typed = item as Record<string, unknown>;
+		if (fieldKey === 'characters' && typeof typed.name === 'string') {
+			const role = typeof typed.role === 'string' ? typed.role : '';
+			return role ? `${typed.name} (${role})` : typed.name;
+		}
+		if (fieldKey === 'mechanics' && typeof typed.label === 'string') {
+			const key = typeof typed.key === 'string' ? typed.key : '';
+			return key ? `${typed.label} [${key}]` : typed.label;
+		}
+		// Last-resort fallback — stringify but keep it short.
+		try {
+			return truncate(JSON.stringify(item));
+		} catch {
+			return '(unprintable)';
+		}
+	}
+
+	function arraySignature(item: unknown, fieldKey: string): string {
+		// Identity used to compute added/removed sets. For strings that's the
+		// string itself; for object arrays we use a stable canonical form.
+		if (typeof item === 'string') return item;
+		if (item == null) return '';
+		try {
+			return `${fieldKey}::${JSON.stringify(item)}`;
+		} catch {
+			return `${fieldKey}::unprintable`;
+		}
+	}
+
+	function computeDiff(
+		oldDraft: BuilderStoryDraft,
+		newDraft: BuilderStoryDraft
+	): DiffEntry[] {
+		const entries: DiffEntry[] = [];
+
+		for (const field of STRING_FIELDS) {
+			const oldValue = (oldDraft[field] as string | undefined) ?? '';
+			const newValue = (newDraft[field] as string | undefined) ?? '';
+			if (oldValue !== newValue) {
+				entries.push({
+					field: String(field),
+					kind: 'string',
+					oldValue,
+					newValue
+				});
+			}
+		}
+
+		const arrayFields: Array<keyof BuilderStoryDraft> = [
+			'voiceCeilingLines',
+			'characters',
+			'mechanics'
+		];
+		for (const field of arrayFields) {
+			const oldArr = Array.isArray(oldDraft[field])
+				? (oldDraft[field] as unknown as readonly unknown[])
+				: [];
+			const newArr = Array.isArray(newDraft[field])
+				? (newDraft[field] as unknown as readonly unknown[])
+				: [];
+			const oldSigs = oldArr.map((item) => arraySignature(item, String(field)));
+			const newSigs = newArr.map((item) => arraySignature(item, String(field)));
+			const oldSigSet = new Set(oldSigs);
+			const newSigSet = new Set(newSigs);
+
+			const added: string[] = [];
+			const removed: string[] = [];
+			newArr.forEach((item, index) => {
+				if (!oldSigSet.has(newSigs[index])) {
+					added.push(describeArrayItem(item, String(field)));
+				}
+			});
+			oldArr.forEach((item, index) => {
+				if (!newSigSet.has(oldSigs[index])) {
+					removed.push(describeArrayItem(item, String(field)));
+				}
+			});
+
+			const countChanged = oldArr.length !== newArr.length;
+			if (countChanged || added.length > 0 || removed.length > 0) {
+				entries.push({
+					field: String(field),
+					kind: 'array',
+					oldCount: oldArr.length,
+					newCount: newArr.length,
+					added,
+					removed
+				});
+			}
+		}
+
+		return entries;
+	}
+
+	function formatCreatedAt(value: string): string {
+		try {
+			const date = new Date(value);
+			if (Number.isNaN(date.getTime())) return value;
+			return date.toLocaleString();
+		} catch {
+			return value;
+		}
+	}
+
+	// Eagerly fetch the snapshot list on mount so the dropdown is populated.
+	refreshSnapshotList();
+</script>
+
+<section class="draft-diff" aria-label="Draft version comparison">
+	<header class="diff-head">
+		<div>
+			<p class="diff-kicker">Draft history</p>
+			<h3>Version comparison</h3>
+		</div>
+		<button
+			type="button"
+			class="diff-button"
+			on:click={saveSnapshot}
+			disabled={saveState === 'saving'}
+			data-testid="draft-diff-save"
+		>
+			{saveState === 'saving' ? 'Saving…' : saveState === 'saved' ? 'Saved' : 'Save snapshot'}
+		</button>
+	</header>
+
+	{#if saveState === 'error'}
+		<p class="diff-error" role="alert">{saveError}</p>
+	{/if}
+
+	<label class="diff-picker" for="draft-diff-snapshot">
+		<span>Compare against</span>
+		<select
+			id="draft-diff-snapshot"
+			class="diff-select"
+			value={selectedId ?? ''}
+			on:change={handleSelectChange}
+			disabled={listState === 'loading'}
+			data-testid="draft-diff-select"
+		>
+			<option value="">— No snapshot selected —</option>
+			{#each snapshots as snap (snap.id)}
+				<option value={snap.id}>
+					{snap.draft_title} · {formatCreatedAt(snap.created_at)}
+				</option>
+			{/each}
+		</select>
+	</label>
+
+	{#if listState === 'error'}
+		<p class="diff-error" role="alert">{listError}</p>
+	{:else if listState === 'ready' && snapshots.length === 0}
+		<p class="diff-empty">
+			No snapshots yet. Save one before you regenerate to see what changed.
+		</p>
+	{/if}
+
+	{#if !selectedId}
+		<p class="diff-empty">
+			Select a saved snapshot above to diff it against the current draft.
+		</p>
+	{:else if detailState === 'loading'}
+		<p class="diff-empty" aria-live="polite">Loading snapshot…</p>
+	{:else if detailState === 'error'}
+		<p class="diff-error" role="alert">{detailError}</p>
+	{:else if detailState === 'ready' && detail}
+		<div class="diff-meta">
+			<p>
+				Snapshot: <strong>{detail.draft_title}</strong>
+			</p>
+			<p>Saved {formatCreatedAt(detail.created_at)}</p>
+		</div>
+		{#if diffEntries.length === 0}
+			<p class="diff-empty">No differences — the current draft matches this snapshot.</p>
+		{:else}
+			<ul class="diff-list">
+				{#each diffEntries as entry, index (index)}
+					<li class="diff-entry" data-kind={entry.kind}>
+						<p class="diff-entry-field"><code>{entry.field}</code></p>
+						{#if entry.kind === 'string'}
+							<div class="diff-string">
+								<p class="diff-old">
+									<span class="diff-old-label">Was</span>
+									<span class="diff-old-text">{truncate(entry.oldValue) || '(empty)'}</span>
+								</p>
+								<p class="diff-new">
+									<span class="diff-new-label">Now</span>
+									<span class="diff-new-text">{truncate(entry.newValue) || '(empty)'}</span>
+								</p>
+							</div>
+						{:else}
+							<p class="diff-count">
+								{entry.oldCount} item{entry.oldCount === 1 ? '' : 's'} → {entry.newCount} item{entry.newCount === 1 ? '' : 's'}
+							</p>
+							{#if entry.added.length > 0}
+								<div class="diff-array-block diff-added">
+									<p class="diff-array-label">Added</p>
+									<ul>
+										{#each entry.added as item, addIndex (addIndex)}
+											<li>{truncate(item)}</li>
+										{/each}
+									</ul>
+								</div>
+							{/if}
+							{#if entry.removed.length > 0}
+								<div class="diff-array-block diff-removed">
+									<p class="diff-array-label">Removed</p>
+									<ul>
+										{#each entry.removed as item, rmIndex (rmIndex)}
+											<li>{truncate(item)}</li>
+										{/each}
+									</ul>
+								</div>
+							{/if}
+						{/if}
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	{/if}
+</section>
+
+<style>
+	.draft-diff {
+		--diff-accent: var(--accent-bright, #6366f1);
+		--diff-add: var(--sage-400, #22c55e);
+		--diff-remove: var(--amber-400, #f59e0b);
+		--diff-card-bg: rgba(18, 12, 9, 0.92);
+		--diff-card-border: var(--line-soft, rgba(247, 241, 232, 0.12));
+		--diff-card-border-strong: var(--line-strong, rgba(247, 241, 232, 0.22));
+		--diff-text: var(--text-100, #f7f1e8);
+		--diff-text-dim: var(--text-300, #b8aa9d);
+		display: grid;
+		gap: 0.85rem;
+		padding: 1rem;
+		border: 1px solid var(--diff-card-border);
+		border-radius: 16px;
+		background: linear-gradient(180deg, rgba(18, 12, 9, 0.92), rgba(10, 8, 7, 0.96));
+		box-shadow: var(--shadow-md, 0 16px 36px rgba(0, 0, 0, 0.22));
+		color: var(--diff-text);
+	}
+
+	.diff-head {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 0.75rem;
+	}
+
+	.diff-head h3 {
+		margin: 0.1rem 0 0;
+		font-family: var(--font-display, serif);
+		font-size: 1.1rem;
+		color: var(--diff-text);
+	}
+
+	.diff-kicker {
+		margin: 0;
+		text-transform: uppercase;
+		letter-spacing: 0.14em;
+		font-size: 0.68rem;
+		color: var(--diff-text-dim);
+	}
+
+	.diff-button {
+		appearance: none;
+		border: 1px solid var(--diff-card-border-strong);
+		background: rgba(247, 241, 232, 0.04);
+		color: var(--diff-text);
+		font: inherit;
+		font-size: 0.82rem;
+		padding: 0.45rem 0.85rem;
+		border-radius: 8px;
+		cursor: pointer;
+		transition: background 120ms ease-out, border-color 120ms ease-out;
+	}
+
+	.diff-button:hover:not(:disabled) {
+		background: rgba(247, 241, 232, 0.08);
+		border-color: var(--diff-accent);
+	}
+
+	.diff-button:disabled {
+		cursor: not-allowed;
+		opacity: 0.55;
+	}
+
+	.diff-picker {
+		display: grid;
+		gap: 0.35rem;
+		font-size: 0.72rem;
+		color: var(--diff-text-dim);
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+	}
+
+	.diff-select {
+		appearance: none;
+		border: 1px solid var(--diff-card-border-strong);
+		background: rgba(9, 7, 7, 0.55);
+		color: var(--diff-text);
+		font: inherit;
+		font-size: 0.9rem;
+		padding: 0.5rem 0.75rem;
+		border-radius: 8px;
+		text-transform: none;
+		letter-spacing: normal;
+	}
+
+	.diff-select:focus {
+		outline: none;
+		border-color: var(--diff-accent);
+	}
+
+	.diff-meta {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
+		gap: 0.4rem;
+		font-size: 0.78rem;
+		color: var(--diff-text-dim);
+	}
+
+	.diff-meta p {
+		margin: 0;
+	}
+
+	.diff-meta strong {
+		color: var(--diff-text);
+		font-weight: 600;
+	}
+
+	.diff-empty {
+		margin: 0;
+		padding: 0.85rem;
+		border: 1px dashed var(--diff-card-border-strong);
+		border-radius: 12px;
+		color: var(--diff-text-dim);
+		font-size: 0.88rem;
+	}
+
+	.diff-error {
+		margin: 0;
+		padding: 0.85rem;
+		border: 1px solid var(--diff-remove);
+		border-radius: 12px;
+		color: var(--diff-text);
+		background: rgba(245, 158, 11, 0.08);
+		font-size: 0.88rem;
+	}
+
+	.diff-list {
+		list-style: none;
+		display: grid;
+		gap: 0.6rem;
+		margin: 0;
+		padding: 0;
+	}
+
+	.diff-entry {
+		display: grid;
+		gap: 0.4rem;
+		padding: 0.7rem 0.8rem;
+		border: 1px solid var(--diff-card-border-strong);
+		border-left: 3px solid var(--diff-accent);
+		border-radius: 10px;
+		background: rgba(9, 7, 7, 0.55);
+	}
+
+	.diff-entry-field {
+		margin: 0;
+	}
+
+	.diff-entry-field code {
+		font-family: var(--font-mono, monospace);
+		font-size: 0.78rem;
+		padding: 0.1rem 0.4rem;
+		border-radius: 6px;
+		background: rgba(247, 241, 232, 0.08);
+		color: var(--diff-text);
+		letter-spacing: 0.02em;
+	}
+
+	.diff-string {
+		display: grid;
+		gap: 0.35rem;
+	}
+
+	.diff-old,
+	.diff-new {
+		margin: 0;
+		display: grid;
+		grid-template-columns: 3.5rem 1fr;
+		align-items: baseline;
+		gap: 0.5rem;
+		font-size: 0.86rem;
+		line-height: 1.4;
+	}
+
+	.diff-old-label,
+	.diff-new-label {
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		font-size: 0.66rem;
+		font-weight: 700;
+	}
+
+	.diff-old-label {
+		color: var(--diff-remove);
+	}
+
+	.diff-new-label {
+		color: var(--diff-add);
+	}
+
+	.diff-old-text {
+		color: var(--diff-text-dim);
+		text-decoration: line-through;
+	}
+
+	.diff-new-text {
+		color: var(--diff-text);
+		background: rgba(34, 197, 94, 0.08);
+		padding: 0.05rem 0.3rem;
+		border-radius: 4px;
+	}
+
+	.diff-count {
+		margin: 0;
+		font-size: 0.86rem;
+		color: var(--diff-text);
+	}
+
+	.diff-array-block {
+		display: grid;
+		gap: 0.25rem;
+		padding: 0.5rem 0.6rem;
+		border-radius: 8px;
+		background: rgba(247, 241, 232, 0.04);
+	}
+
+	.diff-array-block.diff-added {
+		border-left: 2px solid var(--diff-add);
+	}
+
+	.diff-array-block.diff-removed {
+		border-left: 2px solid var(--diff-remove);
+	}
+
+	.diff-array-label {
+		margin: 0;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		font-size: 0.66rem;
+		font-weight: 700;
+		color: var(--diff-text-dim);
+	}
+
+	.diff-array-block.diff-added .diff-array-label {
+		color: var(--diff-add);
+	}
+
+	.diff-array-block.diff-removed .diff-array-label {
+		color: var(--diff-remove);
+	}
+
+	.diff-array-block ul {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: grid;
+		gap: 0.2rem;
+	}
+
+	.diff-array-block li {
+		font-size: 0.84rem;
+		color: var(--diff-text);
+		line-height: 1.35;
+	}
+
+	.diff-array-block.diff-removed li {
+		color: var(--diff-text-dim);
+		text-decoration: line-through;
+	}
+</style>

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -2,7 +2,8 @@
  * TypeScript types for the Supabase database schema.
  *
  * These mirror the SQL tables defined in
- * supabase/migrations/20260510000000_initial_schema.sql
+ * supabase/migrations/20260510000000_initial_schema.sql and
+ * supabase/migrations/20260511000000_draft_versions.sql
  * and follow the Supabase generated-types convention so they can be replaced
  * by `supabase gen types typescript` once the project is provisioned.
  */
@@ -33,6 +34,15 @@ export interface BuilderDraftRow {
 	updated_at: string;
 }
 
+export interface DraftVersionRow {
+	id: string;
+	session_user_id: string;
+	draft_title: string;
+	/** Serialised BuilderStoryDraft snapshot (see src/lib/stories/types.ts) */
+	snapshot: Record<string, unknown>;
+	created_at: string;
+}
+
 // ─── Insert / Update shapes ───────────────────────────────────────────────────
 
 export type PlaySessionInsert = Omit<PlaySessionRow, 'id' | 'created_at' | 'updated_at'>;
@@ -40,6 +50,9 @@ export type PlaySessionUpdate = Partial<Omit<PlaySessionRow, 'id' | 'created_at'
 
 export type BuilderDraftInsert = Omit<BuilderDraftRow, 'id' | 'created_at' | 'updated_at'>;
 export type BuilderDraftUpdate = Partial<Omit<BuilderDraftRow, 'id' | 'created_at'>>;
+
+export type DraftVersionInsert = Omit<DraftVersionRow, 'id' | 'created_at'>;
+export type DraftVersionUpdate = Partial<Omit<DraftVersionRow, 'id' | 'created_at'>>;
 
 // ─── Database type (passed to createClient<Database>()) ──────────────────────
 
@@ -55,6 +68,11 @@ export interface Database {
 				Row: BuilderDraftRow;
 				Insert: BuilderDraftInsert;
 				Update: BuilderDraftUpdate;
+			};
+			draft_versions: {
+				Row: DraftVersionRow;
+				Insert: DraftVersionInsert;
+				Update: DraftVersionUpdate;
 			};
 		};
 	};

--- a/src/routes/api/builder/snapshot/+server.ts
+++ b/src/routes/api/builder/snapshot/+server.ts
@@ -1,0 +1,93 @@
+/**
+ * Builder draft snapshot endpoint.
+ *
+ * POST  /api/builder/snapshot
+ *   Body: { draft: BuilderStoryDraft }
+ *   Saves a point-in-time JSONB snapshot of the current draft into
+ *   public.draft_versions so the author can diff a future regeneration
+ *   against it. Returns { id, created_at } on success.
+ *
+ * The userId is taken from locals.sessionUser (the same hook used by every
+ * other builder route — see alignment/+server.ts and evaluate-voice/+server.ts).
+ */
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { getSupabaseClient } from '$lib/server/db/supabase';
+import type { BuilderStoryDraft } from '$lib/stories/types';
+
+export interface SnapshotCreateResponse {
+	id: string;
+	created_at: string;
+}
+
+function isDraft(value: unknown): value is BuilderStoryDraft {
+	if (!value || typeof value !== 'object') return false;
+	const typed = value as Partial<BuilderStoryDraft>;
+	return (
+		typeof typed.title === 'string' &&
+		typeof typed.premise === 'string' &&
+		Array.isArray(typed.characters) &&
+		Array.isArray(typed.mechanics)
+	);
+}
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+	const payload = (await request.json().catch(() => ({}))) as { draft?: unknown };
+	const draft = payload.draft;
+
+	if (!isDraft(draft)) {
+		return json(
+			{ error: 'Missing or invalid builder draft in request body.', code: 'invalid_request' },
+			{ status: 400 }
+		);
+	}
+
+	const userId = locals.sessionUser?.userId;
+	if (!userId) {
+		return json(
+			{ error: 'No session user; sign in before saving snapshots.', code: 'no_session' },
+			{ status: 401 }
+		);
+	}
+
+	const client = getSupabaseClient();
+	if (!client) {
+		return json(
+			{
+				error: 'Snapshot storage is not configured on this environment.',
+				code: 'storage_unavailable'
+			},
+			{ status: 503 }
+		);
+	}
+
+	const draftTitle =
+		typeof draft.title === 'string' && draft.title.trim() ? draft.title.trim() : 'Untitled draft';
+
+	const { data, error } = await client
+		.from('draft_versions')
+		.insert({
+			session_user_id: userId,
+			draft_title: draftTitle,
+			snapshot: draft as unknown as Record<string, unknown>
+		})
+		.select('id, created_at')
+		.limit(1)
+		.single();
+
+	if (error || !data) {
+		console.error(
+			'[api:snapshot] insert failed:',
+			error instanceof Error ? error.message : error
+		);
+		return json(
+			{ error: 'Failed to save snapshot.', code: 'storage_error' },
+			{ status: 500 }
+		);
+	}
+
+	const response: SnapshotCreateResponse = {
+		id: data.id as string,
+		created_at: data.created_at as string
+	};
+	return json(response);
+};

--- a/src/routes/api/builder/snapshot/[id]/+server.ts
+++ b/src/routes/api/builder/snapshot/[id]/+server.ts
@@ -1,0 +1,82 @@
+/**
+ * Single snapshot fetch endpoint.
+ *
+ * GET  /api/builder/snapshot/[id]
+ *   Returns the full snapshot JSONB for one draft_versions row, scoped to
+ *   the current session user. Used by DraftDiff to compute a field-by-field
+ *   diff against the in-memory draft.
+ *
+ * Returns { id, draft_title, created_at, snapshot } on success.
+ */
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { getSupabaseClient } from '$lib/server/db/supabase';
+import type { BuilderStoryDraft } from '$lib/stories/types';
+
+export interface SnapshotDetailResponse {
+	id: string;
+	draft_title: string;
+	created_at: string;
+	snapshot: BuilderStoryDraft;
+}
+
+export const GET: RequestHandler = async ({ params, locals }) => {
+	const id = params.id?.trim();
+	if (!id) {
+		return json(
+			{ error: 'Missing snapshot id.', code: 'invalid_request' },
+			{ status: 400 }
+		);
+	}
+
+	const userId = locals.sessionUser?.userId;
+	if (!userId) {
+		return json(
+			{ error: 'No session user; sign in before loading snapshots.', code: 'no_session' },
+			{ status: 401 }
+		);
+	}
+
+	const client = getSupabaseClient();
+	if (!client) {
+		return json(
+			{
+				error: 'Snapshot storage is not configured on this environment.',
+				code: 'storage_unavailable'
+			},
+			{ status: 503 }
+		);
+	}
+
+	const { data, error } = await client
+		.from('draft_versions')
+		.select('id, draft_title, snapshot, created_at, session_user_id')
+		.eq('id', id)
+		.eq('session_user_id', userId)
+		.maybeSingle();
+
+	if (error) {
+		console.error(
+			'[api:snapshot:get] select failed:',
+			error instanceof Error ? error.message : error
+		);
+		return json(
+			{ error: 'Failed to load snapshot.', code: 'storage_error' },
+			{ status: 500 }
+		);
+	}
+
+	if (!data) {
+		return json(
+			{ error: 'Snapshot not found.', code: 'not_found' },
+			{ status: 404 }
+		);
+	}
+
+	const response: SnapshotDetailResponse = {
+		id: data.id as string,
+		draft_title: data.draft_title as string,
+		created_at: data.created_at as string,
+		snapshot: data.snapshot as unknown as BuilderStoryDraft
+	};
+	return json(response);
+};

--- a/src/routes/api/builder/snapshots/+server.ts
+++ b/src/routes/api/builder/snapshots/+server.ts
@@ -1,0 +1,68 @@
+/**
+ * Snapshot index endpoint.
+ *
+ * GET  /api/builder/snapshots
+ *   Returns the last 5 snapshots for the current session user as a lightweight
+ *   list — id, draft_title, created_at only (no JSONB payload) — so the
+ *   DraftDiff dropdown can render without pulling every full snapshot.
+ */
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { getSupabaseClient } from '$lib/server/db/supabase';
+
+export interface SnapshotSummary {
+	id: string;
+	draft_title: string;
+	created_at: string;
+}
+
+export interface SnapshotListResponse {
+	snapshots: SnapshotSummary[];
+}
+
+const MAX_SNAPSHOTS = 5;
+
+export const GET: RequestHandler = async ({ locals }) => {
+	const userId = locals.sessionUser?.userId;
+	if (!userId) {
+		return json(
+			{ error: 'No session user; sign in before listing snapshots.', code: 'no_session' },
+			{ status: 401 }
+		);
+	}
+
+	const client = getSupabaseClient();
+	if (!client) {
+		// Treat unconfigured storage as an empty list rather than a hard error —
+		// the builder page should still load in local-dev environments without
+		// Supabase configured.
+		const empty: SnapshotListResponse = { snapshots: [] };
+		return json(empty);
+	}
+
+	const { data, error } = await client
+		.from('draft_versions')
+		.select('id, draft_title, created_at')
+		.eq('session_user_id', userId)
+		.order('created_at', { ascending: false })
+		.limit(MAX_SNAPSHOTS);
+
+	if (error) {
+		console.error(
+			'[api:snapshots] select failed:',
+			error instanceof Error ? error.message : error
+		);
+		return json(
+			{ error: 'Failed to list snapshots.', code: 'storage_error' },
+			{ status: 500 }
+		);
+	}
+
+	const snapshots: SnapshotSummary[] = (data ?? []).map((row) => ({
+		id: row.id as string,
+		draft_title: row.draft_title as string,
+		created_at: row.created_at as string
+	}));
+
+	const response: SnapshotListResponse = { snapshots };
+	return json(response);
+};

--- a/src/routes/builder/+page.svelte
+++ b/src/routes/builder/+page.svelte
@@ -6,6 +6,7 @@
 	import BranchMap, { type BranchMapNode } from '$lib/components/builder/BranchMap.svelte';
 	import AlignmentScore from '$lib/components/builder/AlignmentScore.svelte';
 	import VoiceEvaluator from '$lib/components/builder/VoiceEvaluator.svelte';
+	import DraftDiff from '$lib/components/builder/DraftDiff.svelte';
 	import { lessons } from '$lib/narrative/lessonsCatalog';
 	import type {
 		BuilderDraftEvaluation,
@@ -38,6 +39,17 @@
 	let activeNodeId: string | null = 'root:story';
 	let branchMapCollapsed = false;
 	let alignmentLessonId: string = lessons[0] ? String(lessons[0].id) : '';
+	let snapshotId: string | null = null;
+
+	function handleSnapshotSelected(event: CustomEvent<{ id: string | null }>): void {
+		snapshotId = event.detail.id;
+	}
+
+	function handleSnapshotSaved(event: CustomEvent<{ id: string; createdAt: string }>): void {
+		// Default the diff view to compare against the freshly saved snapshot so
+		// the author sees exactly what the next regeneration changed.
+		snapshotId = event.detail.id;
+	}
 
 	onMount(() => {
 		draft = loadBuilderDraft(draftScope, fallbackDraft);
@@ -707,6 +719,14 @@
 			<div class="builder-rail-card builder-rail-voice" data-testid="builder-voice-evaluator">
 				<VoiceEvaluator {draft} />
 			</div>
+			<div class="builder-rail-card builder-rail-diff" data-testid="builder-draft-diff">
+				<DraftDiff
+					currentDraft={draft}
+					{snapshotId}
+					on:snapshotSelected={handleSnapshotSelected}
+					on:snapshotSaved={handleSnapshotSaved}
+				/>
+			</div>
 			<div class="builder-rail-card">
 				<h3>Gold medal bar</h3>
 				<p class="builder-rail-copy">
@@ -785,6 +805,10 @@
 	}
 
 	.builder-rail-voice {
+		padding: 0.75rem;
+	}
+
+	.builder-rail-diff {
 		padding: 0.75rem;
 	}
 </style>

--- a/supabase/migrations/20260511000000_draft_versions.sql
+++ b/supabase/migrations/20260511000000_draft_versions.sql
@@ -1,0 +1,30 @@
+-- Migration: 20260511000000_draft_versions
+-- Adds draft snapshot history so authors can compare draft regenerations.
+-- Apply with: supabase db push  (or via the Supabase dashboard SQL editor)
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- DRAFT VERSIONS
+-- Append-only history of builder draft snapshots. Each row captures the full
+-- BuilderStoryDraft JSON at the moment the author saved a snapshot, so a
+-- subsequent regeneration can be diffed against it field-by-field.
+-- ─────────────────────────────────────────────────────────────────────────────
+create table if not exists public.draft_versions (
+  id uuid primary key default gen_random_uuid(),
+  session_user_id text not null,
+  draft_title text not null,
+  snapshot jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+create index draft_versions_user_idx on public.draft_versions(session_user_id, created_at desc);
+
+-- RLS: users can only see their own snapshots
+alter table public.draft_versions enable row level security;
+
+create policy "users see own draft versions"
+  on public.draft_versions for select
+  using (session_user_id = current_setting('app.current_user_id', true));
+
+create policy "users insert own draft versions"
+  on public.draft_versions for insert
+  with check (session_user_id = current_setting('app.current_user_id', true));


### PR DESCRIPTION
## Summary

Authors regenerate builder drafts and have no way to tell whether the new version is better or worse without replaying the whole story. Sprint 16 adds:

- **Draft snapshots** — Save a JSONB snapshot of the current draft to Supabase before overwriting.
- **Diff view** — A new rail card on the builder page that compares the current in-memory draft to any of the last 5 saved snapshots, field by field.

## Changes

### Storage
- `supabase/migrations/20260511000000_draft_versions.sql` — new append-only `draft_versions` table keyed by `session_user_id`, with RLS policies that scope select/insert to `current_setting('app.current_user_id', true)` and an index on `(session_user_id, created_at desc)` for fast list reads.
- `src/lib/server/db/schema.ts` — extends the typed `Database` shape with `draft_versions` so the existing `createClient<Database>()` call accepts the new table without any runtime cast hacks.

### API routes
All three new routes use the existing Supabase pattern (`getSupabaseClient()` from `$lib/server/db/supabase`) and read the user id from `locals.sessionUser?.userId` exactly the way `alignment/+server.ts` and `evaluate-voice/+server.ts` already do. They degrade cleanly when Supabase env vars are absent.

- `POST /api/builder/snapshot` — `{ draft }` → `{ id, created_at }`. Validates the payload, stores the full BuilderStoryDraft as JSONB. Returns 401 if no session user, 503 if Supabase is unconfigured.
- `GET /api/builder/snapshot/[id]` — Returns one snapshot row, double-scoped on `session_user_id` so a user can never load another user's snapshot even via direct id.
- `GET /api/builder/snapshots` — Lightweight list of the last 5 snapshots (id, draft_title, created_at only). Returns an empty list when Supabase is unconfigured so the page still renders in local dev.

### UI
- `src/lib/components/builder/DraftDiff.svelte` — new rail card matching `AlignmentScore.svelte`'s visual language (same card chrome, button style, accent variables). Includes:
  - A **Save snapshot** button that POSTs the current draft and refreshes the dropdown.
  - A **dropdown** of the last 5 snapshots (auto-loaded on mount).
  - A **field-by-field diff** that truncates string fields at 120 chars with `…` and renders old (strikethrough/dim) vs. new (highlighted).
  - **Array diffs** for `voiceCeilingLines`, `characters`, and `mechanics` showing `N items → M items` plus added/removed entries with role/key labels for object items.
- `src/routes/builder/+page.svelte` — imports `DraftDiff`, declares a `snapshotId` state variable, and mounts the component as the fourth rail card below `VoiceEvaluator`. BranchMap, AlignmentScore, and VoiceEvaluator integrations are untouched.

## Constraints honored
- Svelte 4 idioms throughout (`export let`, `$:`, `on:click`, `createEventDispatcher`) — matches existing components.
- TypeScript end-to-end; no `any`.
- No new npm dependencies.
- Uses the existing Supabase client factory (`$lib/server/db/supabase`) — no new client construction.

## Test plan
- [ ] Apply migration: `supabase db push` (or run the SQL in the Supabase dashboard) — verify `public.draft_versions` exists with RLS enabled and the two policies attached.
- [ ] Open the builder page — confirm the new "Version comparison" rail card renders below the voice evaluator with the empty-state copy.
- [ ] Click **Save snapshot** — verify the button reports "Saved", the dropdown refreshes, and a row appears in `draft_versions` with the full draft JSONB.
- [ ] Edit a string field (e.g. title) and select the saved snapshot in the dropdown — confirm the diff shows that field with old struck-through and new highlighted.
- [ ] Add a character, remove a voice ceiling line — confirm array diffs show `N → M` and the added/removed lists.
- [ ] Save a string field longer than 120 chars, edit it, diff — confirm both old and new are truncated with `…`.
- [ ] Verify `BranchMap`, `AlignmentScore`, and `VoiceEvaluator` still render and behave exactly as on `main`.
- [ ] Hit `/api/builder/snapshot/<bogus-id>` while logged in — expect 404.
- [ ] Unset `SUPABASE_URL` locally — confirm `/api/builder/snapshots` returns `{ snapshots: [] }` and POST returns 503 cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)