### PR TITLE
feat(sprint-17): one-click story remix with lesson swap for builder

### DIFF
--- a/src/lib/components/builder/RemixButton.svelte
+++ b/src/lib/components/builder/RemixButton.svelte
@@ -1,0 +1,365 @@
+<script lang="ts" context="module">
+	export interface RemixResponsePayload {
+		draft: BuilderStoryDraft;
+		source: 'ai' | 'fallback';
+		lesson: { id: number; title: string };
+	}
+</script>
+
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import { lessons } from '$lib/narrative/lessonsCatalog';
+	import type { BuilderStoryDraft } from '$lib/stories/types';
+
+	export let draft: BuilderStoryDraft;
+	export let currentLessonId: number;
+	export let title: string = 'Remix with different lesson';
+
+	type ViewState = 'idle' | 'confirming' | 'loading' | 'ready' | 'error';
+
+	const dispatch = createEventDispatcher<{ remixed: { newDraft: BuilderStoryDraft } }>();
+
+	let viewState: ViewState = 'idle';
+	let errorMessage = '';
+	let resultMessage = '';
+	let lastSource: 'ai' | 'fallback' | null = null;
+
+	$: alternativeLessons = lessons.filter((lesson) => lesson.id !== currentLessonId);
+	$: defaultPickerId = alternativeLessons[0]?.id ?? null;
+
+	let selectedLessonId: number | null = null;
+	// Reset the picker default whenever the alternatives change (e.g. the
+	// current lesson on the page changed) and the user has not yet picked.
+	$: if (selectedLessonId === null && defaultPickerId !== null) {
+		selectedLessonId = defaultPickerId;
+	}
+	$: if (
+		selectedLessonId !== null &&
+		!alternativeLessons.some((lesson) => lesson.id === selectedLessonId)
+	) {
+		selectedLessonId = defaultPickerId;
+	}
+
+	$: selectedLesson =
+		selectedLessonId !== null
+			? alternativeLessons.find((lesson) => lesson.id === selectedLessonId) ?? null
+			: null;
+
+	function startConfirmation(): void {
+		if (selectedLesson) {
+			viewState = 'confirming';
+			errorMessage = '';
+		}
+	}
+
+	function cancelConfirmation(): void {
+		viewState = 'idle';
+	}
+
+	async function runRemix(): Promise<void> {
+		if (!selectedLesson) return;
+		viewState = 'loading';
+		errorMessage = '';
+		resultMessage = '';
+		try {
+			const response = await fetch('/api/builder/remix', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ draft, newLessonId: selectedLesson.id })
+			});
+			const payload = (await response.json().catch(() => ({}))) as Partial<
+				RemixResponsePayload & { error: string }
+			>;
+			if (!response.ok || !payload.draft) {
+				throw new Error(payload.error || `Remix failed (${response.status}).`);
+			}
+			lastSource = payload.source ?? null;
+			resultMessage =
+				payload.source === 'ai'
+					? `Remixed around "${selectedLesson.title}" with Grok.`
+					: `Remix fell back to your previous draft. Grok was unavailable.`;
+			viewState = 'ready';
+			dispatch('remixed', { newDraft: payload.draft });
+		} catch (error) {
+			viewState = 'error';
+			errorMessage =
+				error instanceof Error ? error.message : 'Remix failed unexpectedly.';
+		}
+	}
+</script>
+
+<section class="remix-card" aria-label={title}>
+	<header class="remix-head">
+		<div>
+			<p class="remix-kicker">Lesson swap</p>
+			<h3>{title}</h3>
+		</div>
+	</header>
+
+	<p class="remix-warning">
+		Remix will rewrite premise, opening prompt, system prompt, and mechanics. Your setting,
+		characters, and voice ceiling will be preserved.
+	</p>
+
+	{#if alternativeLessons.length === 0}
+		<p class="remix-empty">No other lessons available to remix against.</p>
+	{:else}
+		<label class="remix-picker" for="remix-lesson-picker">
+			<span>Pick a different lesson</span>
+			<select
+				id="remix-lesson-picker"
+				class="remix-select"
+				bind:value={selectedLessonId}
+				disabled={viewState === 'loading' || viewState === 'confirming'}
+				data-testid="remix-lesson-picker"
+			>
+				{#each alternativeLessons as lesson (lesson.id)}
+					<option value={lesson.id}>#{lesson.id} — {lesson.title}</option>
+				{/each}
+			</select>
+		</label>
+
+		{#if viewState === 'idle' || viewState === 'ready' || viewState === 'error'}
+			<button
+				type="button"
+				class="remix-button"
+				on:click={startConfirmation}
+				disabled={!selectedLesson}
+				data-testid="remix-start"
+			>
+				Remix with this lesson
+			</button>
+		{/if}
+
+		{#if viewState === 'confirming' && selectedLesson}
+			<div class="remix-confirm" role="group" aria-label="Confirm remix">
+				<p class="remix-confirm-line">
+					Confirm remix: rewrite premise, opening prompt, system prompt, and mechanics around
+					<strong>#{selectedLesson.id} — {selectedLesson.title}</strong>? Setting, characters,
+					aesthetic statement, and voice ceiling stay as you wrote them.
+				</p>
+				<div class="remix-confirm-actions">
+					<button
+						type="button"
+						class="remix-button remix-button-primary"
+						on:click={runRemix}
+						data-testid="remix-confirm"
+					>
+						Yes, remix
+					</button>
+					<button
+						type="button"
+						class="remix-button remix-button-ghost"
+						on:click={cancelConfirmation}
+						data-testid="remix-cancel"
+					>
+						Cancel
+					</button>
+				</div>
+			</div>
+		{/if}
+
+		{#if viewState === 'loading'}
+			<p class="remix-status" aria-live="polite">Remixing draft around the new lesson…</p>
+		{:else if viewState === 'error'}
+			<p class="remix-error" role="alert">{errorMessage}</p>
+		{:else if viewState === 'ready'}
+			<p class="remix-status remix-status-ok" aria-live="polite">
+				{resultMessage}
+				{#if lastSource}
+					<span class="remix-source"
+						>({lastSource === 'ai' ? 'Grok remix' : 'Fallback'})</span
+					>
+				{/if}
+			</p>
+		{/if}
+	{/if}
+</section>
+
+<style>
+	.remix-card {
+		--remix-accent: var(--accent-bright, #6366f1);
+		--remix-low: var(--amber-400, #f59e0b);
+		--remix-high: var(--sage-400, #22c55e);
+		--remix-card-border: var(--line-soft, rgba(247, 241, 232, 0.12));
+		--remix-card-border-strong: var(--line-strong, rgba(247, 241, 232, 0.22));
+		--remix-text: var(--text-100, #f7f1e8);
+		--remix-text-dim: var(--text-300, #b8aa9d);
+		display: grid;
+		gap: 0.85rem;
+		padding: 1rem;
+		border: 1px solid var(--remix-card-border);
+		border-radius: 16px;
+		background: linear-gradient(180deg, rgba(18, 12, 9, 0.92), rgba(10, 8, 7, 0.96));
+		box-shadow: var(--shadow-md, 0 16px 36px rgba(0, 0, 0, 0.22));
+		color: var(--remix-text);
+	}
+
+	.remix-head {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 0.75rem;
+	}
+
+	.remix-head h3 {
+		margin: 0.1rem 0 0;
+		font-family: var(--font-display, serif);
+		font-size: 1.1rem;
+		color: var(--remix-text);
+	}
+
+	.remix-kicker {
+		margin: 0;
+		text-transform: uppercase;
+		letter-spacing: 0.14em;
+		font-size: 0.68rem;
+		color: var(--remix-text-dim);
+	}
+
+	.remix-warning {
+		margin: 0;
+		padding: 0.75rem;
+		border: 1px dashed var(--remix-card-border-strong);
+		border-radius: 12px;
+		color: var(--remix-text-dim);
+		font-size: 0.85rem;
+		line-height: 1.4;
+	}
+
+	.remix-picker {
+		display: grid;
+		gap: 0.35rem;
+		font-size: 0.78rem;
+		color: var(--remix-text-dim);
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+	}
+
+	.remix-select {
+		appearance: none;
+		border: 1px solid var(--remix-card-border-strong);
+		background: rgba(247, 241, 232, 0.04);
+		color: var(--remix-text);
+		font: inherit;
+		text-transform: none;
+		letter-spacing: normal;
+		font-size: 0.9rem;
+		padding: 0.45rem 0.7rem;
+		border-radius: 8px;
+	}
+
+	.remix-select:disabled {
+		opacity: 0.55;
+		cursor: not-allowed;
+	}
+
+	.remix-button {
+		appearance: none;
+		border: 1px solid var(--remix-card-border-strong);
+		background: rgba(247, 241, 232, 0.04);
+		color: var(--remix-text);
+		font: inherit;
+		font-size: 0.85rem;
+		padding: 0.5rem 0.9rem;
+		border-radius: 8px;
+		cursor: pointer;
+		transition: background 120ms ease-out, border-color 120ms ease-out;
+	}
+
+	.remix-button:hover:not(:disabled) {
+		background: rgba(247, 241, 232, 0.08);
+		border-color: var(--remix-accent);
+	}
+
+	.remix-button:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.remix-button-primary {
+		background: var(--remix-accent);
+		border-color: var(--remix-accent);
+		color: #0a0807;
+		font-weight: 600;
+	}
+
+	.remix-button-primary:hover:not(:disabled) {
+		background: var(--remix-accent);
+		filter: brightness(1.08);
+	}
+
+	.remix-button-ghost {
+		background: transparent;
+	}
+
+	.remix-confirm {
+		display: grid;
+		gap: 0.7rem;
+		padding: 0.85rem;
+		border: 1px solid var(--remix-card-border-strong);
+		border-left: 3px solid var(--remix-low);
+		border-radius: 12px;
+		background: rgba(245, 158, 11, 0.06);
+	}
+
+	.remix-confirm-line {
+		margin: 0;
+		font-size: 0.88rem;
+		line-height: 1.45;
+		color: var(--remix-text);
+	}
+
+	.remix-confirm-line strong {
+		color: var(--remix-text);
+		font-weight: 600;
+	}
+
+	.remix-confirm-actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+
+	.remix-status {
+		margin: 0;
+		padding: 0.75rem;
+		border-radius: 10px;
+		border: 1px solid var(--remix-card-border-strong);
+		background: rgba(9, 7, 7, 0.55);
+		color: var(--remix-text);
+		font-size: 0.86rem;
+		line-height: 1.4;
+	}
+
+	.remix-status-ok {
+		border-left: 3px solid var(--remix-high);
+	}
+
+	.remix-source {
+		display: inline-block;
+		margin-left: 0.35rem;
+		color: var(--remix-text-dim);
+		font-size: 0.78rem;
+	}
+
+	.remix-error {
+		margin: 0;
+		padding: 0.75rem;
+		border: 1px solid var(--remix-low);
+		border-radius: 10px;
+		color: var(--remix-text);
+		background: rgba(245, 158, 11, 0.08);
+		font-size: 0.86rem;
+	}
+
+	.remix-empty {
+		margin: 0;
+		padding: 0.75rem;
+		border: 1px dashed var(--remix-card-border-strong);
+		border-radius: 10px;
+		color: var(--remix-text-dim);
+		font-size: 0.86rem;
+	}
+</style>

--- a/src/lib/server/ai/builder/draftGenerator.ts
+++ b/src/lib/server/ai/builder/draftGenerator.ts
@@ -1,3 +1,4 @@
+import { getLessonById, type Lesson } from '$lib/narrative/lessonsCatalog';
 import { noVacanciesCartridge } from '$lib/stories/no-vacancies';
 import type { BuilderStoryDraft } from '$lib/stories/types';
 import { createFallbackDraft } from './fallbackDraftFactory';
@@ -65,6 +66,103 @@ Generate the first draft now.`;
 		return {
 			draft: createFallbackDraft(trimmedPremise),
 			source: 'fallback'
+		};
+	}
+}
+
+/**
+ * Remix an existing draft against a different lesson.
+ *
+ * Preserves author-crafted identity fields:
+ *   title, setting, characters, aestheticStatement, voiceCeilingLines.
+ *
+ * Rewrites the lesson-coupled fields:
+ *   premise, openingPrompt, systemPrompt, mechanics.
+ *
+ * Falls back to a passthrough of the existing draft if the new lesson is
+ * missing or Grok fails — so a failed remix never wipes the author's work.
+ */
+export async function remixDraft(
+	currentDraft: BuilderStoryDraft,
+	newLessonId: number
+): Promise<{ draft: BuilderStoryDraft; source: 'ai' | 'fallback'; lesson: Lesson }> {
+	const lesson = getLessonById(newLessonId);
+	if (!lesson) {
+		throw new Error(`Unknown lesson id: ${newLessonId}`);
+	}
+
+	const preserved = {
+		title: currentDraft.title,
+		setting: currentDraft.setting,
+		characters: currentDraft.characters,
+		aestheticStatement: currentDraft.aestheticStatement,
+		voiceCeilingLines: currentDraft.voiceCeilingLines
+	};
+
+	const systemPrompt = `You are remixing an existing interactive-narrative draft so it teaches a different lesson while keeping the author's hand-crafted identity intact.
+
+Hard rules:
+- Return the preserved fields EXACTLY as they are provided. Do not paraphrase title, setting, characters, aestheticStatement, or voiceCeilingLines. Copy them verbatim into the response.
+- Rewrite ONLY these four fields so they put the new lesson under behavioral pressure: premise, openingPrompt, systemPrompt, mechanics.
+- Use No Vacancies-style behavioral specificity: motive-driven prose, concrete objects and actions, no trait-summary or therapy-speak.
+- 3-5 mechanics, each with at least 2 voiceMap entries. Mechanic keys/labels should be short and evocative.
+- The new mechanics should track states that surface the new lesson under pressure inside this same setting with these same characters.
+
+Return valid JSON only with this shape:
+{
+  "title": string,
+  "premise": string,
+  "setting": string,
+  "aestheticStatement": string,
+  "voiceCeilingLines": string[],
+  "characters": [{ "name": string, "role": string, "description": string }],
+  "mechanics": [{ "key": string, "label": string, "voiceMap": [{ "value": string, "line": string }] }],
+  "openingPrompt": string,
+  "systemPrompt": string
+}`;
+
+	const userPrompt = `New lesson:
+#${lesson.id} — ${lesson.title}
+Quote: ${lesson.quote}
+Insight: ${lesson.insight}
+Emotional stakes:
+${lesson.emotionalStakes.map((stake) => `- ${stake}`).join('\n')}
+Story triggers:
+${lesson.storyTriggers.map((trigger) => `- ${trigger}`).join('\n')}
+Unconventional angle: ${lesson.unconventionalAngle}
+
+Preserved fields (return these VERBATIM):
+${JSON.stringify(preserved, null, 2)}
+
+Current draft (for context — rewrite premise, openingPrompt, systemPrompt, mechanics to reorient around the new lesson):
+${JSON.stringify(currentDraft, null, 2)}
+
+Remix the draft now. Return JSON only.`;
+
+	try {
+		const raw = await callBuilderModel(systemPrompt, userPrompt);
+		const parsed = JSON.parse(extractJsonObject(raw));
+		const normalized = normalizeDraft(parsed, currentDraft.premise);
+		// Force-preserve the author-crafted fields regardless of what the model
+		// returned. Grok occasionally rephrases them despite the prompt rules.
+		const merged: BuilderStoryDraft = {
+			...normalized,
+			title: preserved.title,
+			setting: preserved.setting,
+			characters: preserved.characters,
+			aestheticStatement: preserved.aestheticStatement,
+			voiceCeilingLines: preserved.voiceCeilingLines
+		};
+		return {
+			draft: merged,
+			source: 'ai',
+			lesson
+		};
+	} catch {
+		return {
+			draft: currentDraft,
+			source: 'fallback',
+			lesson
 		};
 	}
 }

--- a/src/routes/api/builder/remix/+server.ts
+++ b/src/routes/api/builder/remix/+server.ts
@@ -1,0 +1,80 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { remixDraft } from '$lib/server/ai/builder/draftGenerator';
+import { emitAiServerTelemetry } from '$lib/server/ai/telemetry';
+import type { BuilderStoryDraft } from '$lib/stories/types';
+
+interface RemixRequestPayload {
+	draft?: BuilderStoryDraft;
+	newLessonId?: number;
+	draftId?: string;
+}
+
+function isBuilderStoryDraft(value: unknown): value is BuilderStoryDraft {
+	if (!value || typeof value !== 'object') return false;
+	const draft = value as Partial<BuilderStoryDraft>;
+	return (
+		typeof draft.title === 'string' &&
+		typeof draft.premise === 'string' &&
+		typeof draft.setting === 'string' &&
+		typeof draft.aestheticStatement === 'string' &&
+		Array.isArray(draft.voiceCeilingLines) &&
+		Array.isArray(draft.characters) &&
+		Array.isArray(draft.mechanics) &&
+		typeof draft.openingPrompt === 'string' &&
+		typeof draft.systemPrompt === 'string'
+	);
+}
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+	const payload = (await request.json().catch(() => ({}))) as RemixRequestPayload;
+	const draft = payload.draft;
+	const newLessonId =
+		typeof payload.newLessonId === 'number' && Number.isFinite(payload.newLessonId)
+			? Math.trunc(payload.newLessonId)
+			: null;
+	const draftId =
+		typeof payload.draftId === 'string' && payload.draftId.trim()
+			? payload.draftId.trim()
+			: null;
+
+	if (!isBuilderStoryDraft(draft)) {
+		return json({ error: 'Invalid or missing draft payload.' }, { status: 400 });
+	}
+	if (newLessonId === null) {
+		return json({ error: 'newLessonId must be a number.' }, { status: 400 });
+	}
+
+	try {
+		const result = await remixDraft(draft, newLessonId);
+
+		emitAiServerTelemetry('builder_audit', {
+			action: 'remix_draft',
+			userId: locals.sessionUser?.userId ?? 'unknown',
+			draftId,
+			newLessonId,
+			source: result.source,
+			route: '/api/builder/remix'
+		});
+
+		return json({
+			draft: result.draft,
+			source: result.source,
+			lesson: { id: result.lesson.id, title: result.lesson.title }
+		});
+	} catch (error) {
+		const message = error instanceof Error ? error.message : 'Remix failed.';
+		const isInvalidLesson = /Unknown lesson id/i.test(message);
+
+		emitAiServerTelemetry('builder_audit', {
+			action: 'remix_draft',
+			userId: locals.sessionUser?.userId ?? 'unknown',
+			draftId,
+			newLessonId,
+			source: 'error',
+			route: '/api/builder/remix',
+			error: message
+		});
+
+		return json({ error: message }, { status: isInvalidLesson ? 400 : 500 });
+	}
+};

--- a/src/routes/builder/+page.svelte
+++ b/src/routes/builder/+page.svelte
@@ -7,6 +7,7 @@
 	import AlignmentScore from '$lib/components/builder/AlignmentScore.svelte';
 	import VoiceEvaluator from '$lib/components/builder/VoiceEvaluator.svelte';
 	import DraftDiff from '$lib/components/builder/DraftDiff.svelte';
+	import RemixButton from '$lib/components/builder/RemixButton.svelte';
 	import { lessons } from '$lib/narrative/lessonsCatalog';
 	import type {
 		BuilderDraftEvaluation,
@@ -49,6 +50,21 @@
 		// Default the diff view to compare against the freshly saved snapshot so
 		// the author sees exactly what the next regeneration changed.
 		snapshotId = event.detail.id;
+	}
+
+	function handleRemixed(event: CustomEvent<{ newDraft: BuilderStoryDraft }>): void {
+		// Replace the working draft with the remixed version. The rail's
+		// alignmentLessonId already points at the lesson the author swapped to,
+		// so the rest of the page (alignment, voice eval, QA chips, diff)
+		// re-renders against the new draft without further wiring.
+		draft = event.detail.newDraft;
+		// Any in-flight QA is no longer valid against the new draft — clear it
+		// so the readiness pill is honest about what's been graded.
+		draftQa = null;
+		draftQaState = 'idle';
+		lastQaDraftSignature = null;
+		lastDraftSource = 'ai';
+		statusMessage = 'Draft remixed against a different lesson. Re-run QA to grade the remix.';
 	}
 
 	onMount(() => {
@@ -727,6 +743,13 @@
 					on:snapshotSaved={handleSnapshotSaved}
 				/>
 			</div>
+			<div class="builder-rail-card builder-rail-remix" data-testid="builder-remix">
+				<RemixButton
+					{draft}
+					currentLessonId={Number(alignmentLessonId) || 0}
+					on:remixed={handleRemixed}
+				/>
+			</div>
 			<div class="builder-rail-card">
 				<h3>Gold medal bar</h3>
 				<p class="builder-rail-copy">
@@ -809,6 +832,10 @@
 	}
 
 	.builder-rail-diff {
+		padding: 0.75rem;
+	}
+
+	.builder-rail-remix {
 		padding: 0.75rem;
 	}
 </style>


### PR DESCRIPTION
## Summary

Final builder improvement sprint. Authors can now regenerate the current builder draft against a different lesson while preserving the parts they have already crafted.

**Preserved verbatim:** title, setting, characters, aestheticStatement, voiceCeilingLines.

**Rewritten by Grok:** premise, openingPrompt, systemPrompt, mechanics.

A two-step pick-then-confirm flow protects authors from accidentally wiping work; failed remixes fall back to a passthrough of the existing draft.

## Changes

- `src/lib/server/ai/builder/draftGenerator.ts` (modified): adds `remixDraft(currentDraft, newLessonId)`. Resolves the lesson via `getLessonById`, calls `callBuilderModel` with a prompt that hard-pins the preserved fields, parses with `extractJsonObject` + `normalizeDraft`, then force-merges the preserved fields back over the normalized response so a chatty model cannot paraphrase them. Returns `{ draft, source, lesson }`.
- `src/routes/api/builder/remix/+server.ts` (new): POST route accepting `{ draft, newLessonId, draftId? }`. 400 on invalid draft shape or non-numeric lesson id, 400 on unknown lesson id, 500 on Grok failure. Emits `builder_audit` telemetry with `action: 'remix_draft'`.
- `src/lib/components/builder/RemixButton.svelte` (new): rail card with a lesson picker that excludes the current lesson, the explicit warning copy ("Remix will rewrite premise, opening prompt, system prompt, and mechanics. Your setting, characters, and voice ceiling will be preserved."), and a pick -> confirm -> remix flow. Dispatches a `remixed` event with `{ newDraft }`. Visual language matches `AlignmentScore.svelte`.
- `src/routes/builder/+page.svelte` (modified): imports `RemixButton`, mounts it as the fifth rail card directly under `DraftDiff`, and wires the `remixed` event to swap in the new draft + clear stale QA state. `BranchMap`, `AlignmentScore`, `VoiceEvaluator`, and `DraftDiff` integrations are untouched.

## Test plan

- [ ] Pick a lesson in the alignment picker; confirm `RemixButton` excludes that lesson from its dropdown.
- [ ] Pick a different lesson in `RemixButton`, click Remix, see the confirmation copy, click Yes; verify the draft updates and `title` / `setting` / `characters` / `aestheticStatement` / `voiceCeilingLines` are byte-for-byte preserved.
- [ ] Verify `premise`, `openingPrompt`, `systemPrompt`, and `mechanics` are rewritten and lesson-aligned.
- [ ] Verify the QA readiness pill resets after a remix.
- [ ] POST to `/api/builder/remix` with a bad lesson id -> 400; with a malformed draft -> 400.
- [ ] Verify `builder_audit` telemetry emits with `action: 'remix_draft'` and `source` either `ai` or `fallback`.
- [ ] Click Cancel during the confirm step -> draft unchanged.

## Constraints honored

- Svelte 4 idioms (createEventDispatcher, `bind:value`, reactive `$:`).
- TypeScript end-to-end.
- No new npm dependencies.
- Uses existing `callBuilderModel`; no new AI client.
- All four prior-sprint rail cards (BranchMap, AlignmentScore, VoiceEvaluator, DraftDiff) remain mounted and untouched.