### PR TITLE
fix(sprint-19): SSR crash in DraftDiff, localStorage overwrite on mount, stale feedback after remix, empty-draft guard on RemixButton

### DIFF
--- a/src/lib/components/builder/DraftDiff.svelte
+++ b/src/lib/components/builder/DraftDiff.svelte
@@ -34,7 +34,7 @@
 </script>
 
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, onMount } from 'svelte';
 	import type { BuilderStoryDraft } from '$lib/stories/types';
 
 	export let currentDraft: BuilderStoryDraft;
@@ -274,7 +274,11 @@
 	}
 
 	// Eagerly fetch the snapshot list on mount so the dropdown is populated.
-	refreshSnapshotList();
+	// Wrapped in onMount so the fetch only fires in the browser — calling it at
+	// module/component load time runs during SSR and crashes the server render.
+	onMount(() => {
+		refreshSnapshotList();
+	});
 </script>
 
 <section class="draft-diff" aria-label="Draft version comparison">

--- a/src/lib/components/builder/RemixButton.svelte
+++ b/src/lib/components/builder/RemixButton.svelte
@@ -45,6 +45,11 @@
 			? alternativeLessons.find((lesson) => lesson.id === selectedLessonId) ?? null
 			: null;
 
+	// Guard remix on having meaningful draft content. The empty/starter draft
+	// has no real premise to remix against, so kicking off a remix from there
+	// produces noise instead of a useful rewrite.
+	$: hasDraftContent = Boolean(draft?.premise && draft.premise.trim().length >= 20);
+
 	function startConfirmation(): void {
 		if (selectedLesson) {
 			viewState = 'confirming';
@@ -124,11 +129,16 @@
 				type="button"
 				class="remix-button"
 				on:click={startConfirmation}
-				disabled={!selectedLesson}
+				disabled={!selectedLesson || !hasDraftContent}
 				data-testid="remix-start"
 			>
 				Remix with this lesson
 			</button>
+			{#if !hasDraftContent}
+				<p class="remix-empty" data-testid="remix-empty-guard">
+					Generate a draft first before remixing.
+				</p>
+			{/if}
 		{/if}
 
 		{#if viewState === 'confirming' && selectedLesson}

--- a/src/routes/builder/+page.svelte
+++ b/src/routes/builder/+page.svelte
@@ -63,6 +63,10 @@
 		draftQa = null;
 		draftQaState = 'idle';
 		lastQaDraftSignature = null;
+		// Per-field AI feedback was graded against the previous draft. After a
+		// remix the prose has changed, so the old scores and suggestions are
+		// stale — clear them so the UI doesn't show outdated guidance.
+		feedback = {};
 		lastDraftSource = 'ai';
 		statusMessage = 'Draft remixed against a different lesson. Re-run QA to grade the remix.';
 	}
@@ -73,7 +77,10 @@
 		builderReady = true;
 	});
 
-	$: saveBuilderDraft(draftScope, draft);
+	// Gate the reactive save on builderReady so the empty fallback draft cannot
+	// overwrite the author's persisted work before onMount has had a chance to
+	// hydrate `draft` from localStorage.
+	$: if (builderReady) saveBuilderDraft(draftScope, draft);
 
 	$: readinessLabel = draftQa?.evaluation.readiness ?? 'not-run';
 	$: groupedFindings = groupFindings(draftQa?.evaluation.findings ?? []);


### PR DESCRIPTION
## Summary
Fixes four critical/major frontend bugs surfaced in the sprint 19 code review. Scope is intentionally narrow: only `DraftDiff.svelte`, `RemixButton.svelte`, and the `<script>` section of `builder/+page.svelte`. No template/HTML changes.

## Bug 1 — DraftDiff SSR crash
The eager `refreshSnapshotList()` call at the bottom of the component script ran at module/component load time, which means it fired during SSR and crashed the server render with a fetch to `/api/builder/snapshots`. Fix: wrap the call in `onMount(() => { refreshSnapshotList(); })` and add `onMount` to the existing `svelte` import. The fetch now only fires in the browser.

## Bug 2 — Reactive save overwrites localStorage on mount
`$: saveBuilderDraft(draftScope, draft)` fired immediately with the empty fallback draft before `onMount` had a chance to load the author's saved draft from localStorage — nuking saved work on every page load. Fix: gate the reactive save on a `builderReady` flag that already exists in the script and is set to `true` at the end of `onMount` (after `loadBuilderDraft`). The reactive statement becomes `$: if (builderReady) saveBuilderDraft(draftScope, draft);`.

## Bug 3 — handleRemixed leaves stale per-field feedback visible
After a remix the entire draft is replaced, but the per-field AI feedback object (`feedback`) held scores and suggestions graded against the previous prose. Authors saw outdated guidance under fields that now contained different text. Fix: in `handleRemixed`, reset `feedback = {}` alongside the existing `draftQa` / `draftQaState` / `lastQaDraftSignature` resets.

## Bug 4 — RemixButton allows remix on empty/starter draft
The remix button was active even when the author had not generated a real draft yet — remixing the empty starter produces noise instead of a useful rewrite. Fix: derived `hasDraftContent = Boolean(draft?.premise && draft.premise.trim().length >= 20)`. The remix button is now disabled when `!hasDraftContent` and a helper line (`Generate a draft first before remixing.`) is shown.

## Test plan
- [ ] Load `/builder` with SSR enabled; confirm no server-side crash from `/api/builder/snapshots` fetch.
- [ ] Save a draft, refresh the page; confirm the persisted draft survives mount (no overwrite by the empty fallback).
- [ ] Generate a draft, evaluate a few fields to populate feedback chips, then run Remix; confirm the per-field feedback chips disappear with the remixed prose.
- [ ] On a fresh load with the empty starter draft, confirm the Remix button is disabled and the helper copy appears; type a >=20-char premise and generate a draft, confirm the button becomes enabled.
- [ ] Visual check: rail card markup (BranchMap, AlignmentScore, VoiceEvaluator, DraftDiff, RemixButton) unchanged — only the `<script>` section of `+page.svelte` was touched.

## Summary by Sourcery

Fix SSR stability and draft persistence issues in the builder page and tighten remix behaviour around draft content and feedback state.

Bug Fixes:
- Prevent DraftDiff from triggering snapshot fetches during SSR that crash server-side rendering.
- Avoid overwriting a previously saved builder draft in localStorage with the empty fallback draft on initial mount.
- Clear per-field AI feedback after a remix so feedback always matches the current draft content.
- Disable remixing when the builder only has the empty or insufficient draft content to avoid low-value remixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation requiring meaningful draft content before remixing is allowed.

* **Bug Fixes**
  * Fixed stale AI feedback persisting after remixing a draft.
  * Improved draft persistence handling to prevent saving incomplete fallback states.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Phazzie/NoVacancies/pull/93)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->