### PR TITLE
fix(sprint-20): env var resolution, Sydney moments, error logging, DraftDiff UX polish

### DIFF
--- a/src/lib/components/builder/DraftDiff.svelte
+++ b/src/lib/components/builder/DraftDiff.svelte
@@ -34,7 +34,7 @@
 </script>
 
 <script lang="ts">
-	import { createEventDispatcher, onMount } from 'svelte';
+	import { createEventDispatcher, onMount, tick } from 'svelte';
 	import type { BuilderStoryDraft } from '$lib/stories/types';
 
 	export let currentDraft: BuilderStoryDraft;
@@ -144,6 +144,15 @@
 			saveState = 'saved';
 			dispatch('snapshotSaved', { id: payload.id, createdAt: payload.created_at });
 			await refreshSnapshotList();
+			// Reset the button label back to "Save snapshot" after a brief confirmation
+			// window so a subsequent save doesn't show "Saved ✓" while the network
+			// call is still in flight.
+			await tick();
+			setTimeout(() => {
+				if (saveState === 'saved') {
+					saveState = 'idle';
+				}
+			}, 2500);
 		} catch (error) {
 			saveState = 'error';
 			saveError = error instanceof Error ? error.message : 'Failed to save snapshot.';
@@ -294,7 +303,7 @@
 			disabled={saveState === 'saving'}
 			data-testid="draft-diff-save"
 		>
-			{saveState === 'saving' ? 'Saving…' : saveState === 'saved' ? 'Saved' : 'Save snapshot'}
+			{saveState === 'saving' ? 'Saving…' : saveState === 'saved' ? 'Saved ✓' : 'Save snapshot'}
 		</button>
 	</header>
 
@@ -315,7 +324,7 @@
 			<option value="">— No snapshot selected —</option>
 			{#each snapshots as snap (snap.id)}
 				<option value={snap.id}>
-					{snap.draft_title} · {formatCreatedAt(snap.created_at)}
+					{snap.draft_title} — {formatCreatedAt(snap.created_at)} (#{snap.id.slice(-4)})
 				</option>
 			{/each}
 		</select>

--- a/src/lib/server/ai/builder/draftGenerator.ts
+++ b/src/lib/server/ai/builder/draftGenerator.ts
@@ -62,7 +62,12 @@ Generate the first draft now.`;
 			draft: normalizeDraft(parsed, trimmedPremise),
 			source: 'ai'
 		};
-	} catch {
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(
+			'[draftGenerator:generateDraftFromPremise] error — returning fallback draft:',
+			message
+		);
 		return {
 			draft: createFallbackDraft(trimmedPremise),
 			source: 'fallback'
@@ -142,7 +147,11 @@ Remix the draft now. Return JSON only.`;
 	try {
 		const raw = await callBuilderModel(systemPrompt, userPrompt);
 		const parsed = JSON.parse(extractJsonObject(raw));
-		const normalized = normalizeDraft(parsed, currentDraft.premise);
+		// Pass an empty premise as the fallback: in a remix the premise MUST change
+		// to reflect the new lesson. If Grok omits `premise`, surface that as an
+		// empty field (visible to the author) rather than silently preserving the
+		// old, lesson-mismatched premise.
+		const normalized = normalizeDraft(parsed, '');
 		// Force-preserve the author-crafted fields regardless of what the model
 		// returned. Grok occasionally rephrases them despite the prompt rules.
 		const merged: BuilderStoryDraft = {
@@ -158,7 +167,12 @@ Remix the draft now. Return JSON only.`;
 			source: 'ai',
 			lesson
 		};
-	} catch {
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(
+			'[draftGenerator:remixDraft] error — returning current draft as fallback:',
+			message
+		);
 		return {
 			draft: currentDraft,
 			source: 'fallback',

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -1,5 +1,6 @@
 import { json, type RequestEvent } from '@sveltejs/kit';
 import { dev } from '$app/environment';
+import { env } from '$env/dynamic/private';
 
 export const BUILDER_ROLES = ['author', 'editor'] as const;
 export const SESSION_COOKIE_NAME = 'nv_session';
@@ -10,10 +11,20 @@ const encoder = new TextEncoder();
 // can require validating a few signatures at once. Four entries comfortably covers common
 // rollover windows (current + prior keys) without allowing unbounded growth.
 const MAX_CRYPTO_CACHE_SIZE = 4;
+// The cache is keyed on a SHA-256 fingerprint of the secret rather than the raw secret
+// string, so the plaintext secret never lives as a Map key in memory.
 const cryptoKeyCache = new Map<string, CryptoKey>();
 
+async function secretFingerprint(secret: string): Promise<string> {
+	const buf = await crypto.subtle.digest('SHA-256', encoder.encode(secret));
+	return Array.from(new Uint8Array(buf))
+		.map((b) => b.toString(16).padStart(2, '0'))
+		.join('');
+}
+
 async function getOrImportKey(secret: string): Promise<CryptoKey> {
-	const cached = cryptoKeyCache.get(secret);
+	const fingerprint = await secretFingerprint(secret);
+	const cached = cryptoKeyCache.get(fingerprint);
 	if (cached) return cached;
 	const key = await crypto.subtle.importKey(
 		'raw',
@@ -24,12 +35,12 @@ async function getOrImportKey(secret: string): Promise<CryptoKey> {
 	);
 	if (cryptoKeyCache.size >= MAX_CRYPTO_CACHE_SIZE) {
 		// Map iteration order is insertion order; evict the first inserted key (FIFO).
-		const firstInsertedSecret = cryptoKeyCache.keys().next().value;
-		if (firstInsertedSecret) {
-			cryptoKeyCache.delete(firstInsertedSecret);
+		const firstInsertedFingerprint = cryptoKeyCache.keys().next().value;
+		if (firstInsertedFingerprint) {
+			cryptoKeyCache.delete(firstInsertedFingerprint);
 		}
 	}
-	cryptoKeyCache.set(secret, key);
+	cryptoKeyCache.set(fingerprint, key);
 	return key;
 }
 
@@ -183,8 +194,11 @@ export function authErrorResponse({ status, code, message, path }: AuthErrorOpti
 }
 
 export function getAuthSessionSecret(): string | undefined {
-	const runtimeProcess = globalThis as { process?: { env?: Record<string, string | undefined> } };
-	return runtimeProcess.process?.env?.AUTH_SESSION_SECRET;
+	// Use SvelteKit's `$env/dynamic/private`, which is the only env accessor that
+	// resolves correctly across all adapters — including edge runtimes
+	// (Cloudflare Workers, Vercel Edge) where `globalThis.process` is undefined.
+	const value = env.AUTH_SESSION_SECRET;
+	return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 /**
@@ -204,6 +218,7 @@ export function useSecureCookies(url: URL): boolean {
 }
 
 export function isDemoAuthEnabled(): boolean {
-	const runtimeProcess = globalThis as { process?: { env?: Record<string, string | undefined> } };
-	return runtimeProcess.process?.env?.DEMO_AUTH_ENABLED === '1';
+	// Use SvelteKit's `$env/dynamic/private` so this works in edge runtimes where
+	// `globalThis.process` is undefined.
+	return env.DEMO_AUTH_ENABLED === '1';
 }

--- a/src/routes/api/builder/evaluate-voice/+server.ts
+++ b/src/routes/api/builder/evaluate-voice/+server.ts
@@ -31,11 +31,11 @@ export interface VoiceEvaluationResponse {
 }
 
 const SYDNEY_MOMENTS: readonly string[] = [
-	'Receiving a low rating from a customer.',
-	'Being asked to pick up more shifts on top of an already-long day.',
-	'Explaining her situation to a stranger who has just asked what she does for work.',
-	'Deciding in the moment whether to accept another booking when she is already past her limit.',
-	'Noticing, in passing, that she has not slept in a long time.'
+	'Receiving a 1-star rating on a task she completed while running three other jobs simultaneously.',
+	"Being asked by the motel manager if she plans to stay another night — she doesn't have a clear answer.",
+	'Explaining to another motel guest why she has four phones charging at once.',
+	'Deciding whether to accept another booking that would push her past 20 hours awake.',
+	"Noticing she hasn't eaten since yesterday but there's money in one of her accounts."
 ];
 
 function clampScore(value: unknown): number {


### PR DESCRIPTION
## Summary

Four code-review bugs identified in sprint 20 that were not yet fixed. Does not touch `src/routes/builder/+page.svelte` (handled by a separate agent).

### Bug 1 — `src/lib/server/auth.ts`: env var resolution + cache key
- `getAuthSessionSecret()` and `isDemoAuthEnabled()` previously read `globalThis.process?.env?.X`. On edge runtimes (Cloudflare Workers, Vercel Edge) `process` is undefined, so they silently returned `undefined` and every cookie was treated as unauthenticated. Switched both to `$env/dynamic/private`, which is safe across all SvelteKit adapters.
- `cryptoKeyCache` was keyed on the raw secret string, leaving the plaintext secret as a Map key in memory. Added a `secretFingerprint()` helper (SHA-256 hex) and rekeyed the cache on the fingerprint. `getOrImportKey` was already async, so no signature change was needed.

### Bug 2 — `src/routes/api/builder/evaluate-voice/+server.ts`: Sydney moments
- `SYDNEY_MOMENTS` referenced customer ratings, shifts, and bookings — language from a ride-share/delivery app. Rewrote the 5 moments to match the actual story (motel gig worker juggling phones, manager asking about another night, 20 hours awake, money in an account but no food).

### Bug 3 — `src/lib/server/ai/builder/draftGenerator.ts`: silent error swallowing + premise fallback
- `remixDraft` and `generateDraftFromPremise` both had bare `catch {}` blocks returning the fallback with no log. Replaced with classified `console.error` so a Grok failure is visible in logs.
- In `remixDraft`, `normalizeDraft(parsed, currentDraft.premise)` would silently keep the old premise when Grok omitted `premise` — wrong for a remix, where the premise *should* change to match the new lesson. Pass `''` as the fallback so a missing premise surfaces visibly.

### Bug 4 — `src/lib/components/builder/DraftDiff.svelte`: save state + snapshot label
- `saveState` was set to `'saved'` and never reset. The button read "Saved" permanently and subsequent saves showed "Saved ✓" before the network call completed. Added `await tick()` + a 2.5s `setTimeout` that resets back to `idle` (guarded so a new save-in-progress doesn't get clobbered).
- The snapshot dropdown showed `${title} · ${formatDate(created_at)}`, which collides when two snapshots are saved minutes apart with the same draft title. Switched to `${title} — ${formatDate(created_at)} (#${id.slice(-4)})` so each row is distinguishable.
- Also updated the button label to "Saved ✓" (matches the spec).

## Test plan
- [ ] Unit: `getAuthSessionSecret()` returns the configured value on Node and on edge adapters; cookies authenticate on both.
- [ ] Unit: `cryptoKeyCache` keys are 64-char hex fingerprints, not raw secrets.
- [ ] Manual: open the builder, click "Save snapshot" — confirm the button shows "Saved ✓" briefly then fades back to "Save snapshot" after ~2.5s.
- [ ] Manual: save two snapshots with the same draft title minutes apart; confirm the dropdown distinguishes them via the `(#xxxx)` suffix.
- [ ] Manual: trigger a Grok failure during remix — confirm a classified error is logged and the current draft is returned untouched.
- [ ] Manual: run evaluate-voice; confirm the 5 moments in the prompt are motel/gig-worker oriented (not rideshare).